### PR TITLE
Use random nonce for AES-GCM encryption

### DIFF
--- a/src/Aspirate.Secrets/AesGcmCrypter.cs
+++ b/src/Aspirate.Secrets/AesGcmCrypter.cs
@@ -2,19 +2,13 @@ namespace Aspirate.Secrets;
 
 public class AesGcmCrypter : IEncrypter, IDecrypter
 {
+    private const int NonceSize = 12;
     private readonly byte[] _key;
-    private readonly byte[] _saltBytes;
     private readonly int _tagSizeInBytes;
 
-    public AesGcmCrypter(byte[] key, byte[] saltBytes, int tagSizeInBytes)
+    public AesGcmCrypter(byte[] key, int tagSizeInBytes)
     {
-        if (saltBytes.Length != 12)
-        {
-            throw new ArgumentException("The salt must be exactly 12 bytes.", nameof(saltBytes));
-        }
-
         _key = key;
-        _saltBytes = saltBytes;
         _tagSizeInBytes = tagSizeInBytes;
     }
 
@@ -25,14 +19,16 @@ public class AesGcmCrypter : IEncrypter, IDecrypter
         var plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
         var ciphertextBytes = new byte[plaintextBytes.Length];
         var tag = new byte[_tagSizeInBytes];
+        var nonce = new byte[NonceSize];
+        RandomNumberGenerator.Fill(nonce);
 
-        aesGcm.Encrypt(_saltBytes, plaintextBytes, ciphertextBytes, tag);
+        aesGcm.Encrypt(nonce, plaintextBytes, ciphertextBytes, tag);
 
-        // Prepend the salt and the tag to the ciphertext
-        var resultBytes = new byte[_saltBytes.Length + tag.Length + ciphertextBytes.Length];
-        Buffer.BlockCopy(_saltBytes, 0, resultBytes, 0, _saltBytes.Length);
-        Buffer.BlockCopy(tag, 0, resultBytes, _saltBytes.Length, tag.Length);
-        Buffer.BlockCopy(ciphertextBytes, 0, resultBytes, _saltBytes.Length + tag.Length, ciphertextBytes.Length);
+        // Prepend the nonce and the tag to the ciphertext
+        var resultBytes = new byte[NonceSize + tag.Length + ciphertextBytes.Length];
+        Buffer.BlockCopy(nonce, 0, resultBytes, 0, NonceSize);
+        Buffer.BlockCopy(tag, 0, resultBytes, NonceSize, tag.Length);
+        Buffer.BlockCopy(ciphertextBytes, 0, resultBytes, NonceSize + tag.Length, ciphertextBytes.Length);
 
         return Convert.ToBase64String(resultBytes);
     }
@@ -43,16 +39,16 @@ public class AesGcmCrypter : IEncrypter, IDecrypter
 
         var ciphertextBytes = Convert.FromBase64String(ciphertext);
 
-        // Extract the salt and the tag from the ciphertext
-        var salt = new byte[_saltBytes.Length];
+        // Extract the nonce and the tag from the ciphertext
+        var nonce = new byte[NonceSize];
         var tag = new byte[_tagSizeInBytes];
-        var actualCiphertextBytes = new byte[ciphertextBytes.Length - _saltBytes.Length - tag.Length];
-        Buffer.BlockCopy(ciphertextBytes, 0, salt, 0, _saltBytes.Length);
-        Buffer.BlockCopy(ciphertextBytes, _saltBytes.Length, tag, 0, tag.Length);
-        Buffer.BlockCopy(ciphertextBytes, _saltBytes.Length + tag.Length, actualCiphertextBytes, 0, actualCiphertextBytes.Length);
+        var actualCiphertextBytes = new byte[ciphertextBytes.Length - NonceSize - tag.Length];
+        Buffer.BlockCopy(ciphertextBytes, 0, nonce, 0, NonceSize);
+        Buffer.BlockCopy(ciphertextBytes, NonceSize, tag, 0, tag.Length);
+        Buffer.BlockCopy(ciphertextBytes, NonceSize + tag.Length, actualCiphertextBytes, 0, actualCiphertextBytes.Length);
 
         var plaintextBytes = new byte[actualCiphertextBytes.Length];
-        aesGcm.Decrypt(salt, actualCiphertextBytes, tag, plaintextBytes);
+        aesGcm.Decrypt(nonce, actualCiphertextBytes, tag, plaintextBytes);
 
         return Encoding.UTF8.GetString(plaintextBytes);
     }

--- a/src/Aspirate.Secrets/SecretProvider.cs
+++ b/src/Aspirate.Secrets/SecretProvider.cs
@@ -21,7 +21,7 @@ public class SecretProvider(IFileSystem fileSystem) : ISecretProvider
         // Derive a key from the passphrase using Pbkdf2 with SHA256, 1 million iterations.
         using var pbkdf2 = new Rfc2898DeriveBytes(_password, salt: _salt, iterations: 1000000, HashAlgorithmName.SHA256);
         var key = pbkdf2.GetBytes(32); // AES-256-GCM needs a 32-byte key
-        var crypter = new AesGcmCrypter(key, _salt, TagSizeInBytes);
+        var crypter = new AesGcmCrypter(key, TagSizeInBytes);
 
         _encrypter = crypter;
         _decrypter = crypter;


### PR DESCRIPTION
## Summary
- generate a new nonce for every encryption
- embed the nonce in the ciphertext and read it during decryption
- stop passing salt as nonce when constructing the crypter

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686584110440833182bb10daa95ffee7