### PR TITLE
Fix secrets filename references

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Aspirate now includes built-in support for robust secret management, allowing yo
 ### Managing Secrets
 
 During the `generate` and `apply` processes, you will be prompted to input a password.
-This password is used to encrypt your secrets in the secrets file, named `aspirate-secrets.json`, located in the `aspirate-output` directory.
+This password is used to encrypt your secrets in the secrets file, named `aspirate-state.json`, located in the `aspirate-output` directory.
 
 ### Secrets File Contents
 


### PR DESCRIPTION
## Summary
- update README to mention `aspirate-state.json` instead of `aspirate-secrets.json`

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865858d67748331b61c97f27940d0ed