### PR TITLE
Add nonce tests for AES-GCM crypter

### DIFF
--- a/tests/Aspirate.Tests/SecretTests/AesGcmCrypterTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/AesGcmCrypterTests.cs
@@ -1,0 +1,36 @@
+namespace Aspirate.Tests.SecretTests;
+
+public class AesGcmCrypterTests
+{
+    [Fact]
+    public void EncryptValue_SamePlaintextTwice_ShouldProduceDifferentCiphertext()
+    {
+        // Arrange
+        var key = Enumerable.Range(1, 32).Select(i => (byte)i).ToArray();
+        var crypter = new AesGcmCrypter(key, 16);
+        const string plaintext = "hello";
+
+        // Act
+        var ciphertext1 = crypter.EncryptValue(plaintext);
+        var ciphertext2 = crypter.EncryptValue(plaintext);
+
+        // Assert
+        ciphertext1.Should().NotBe(ciphertext2);
+    }
+
+    [Fact]
+    public void DecryptValue_WithStoredNonce_ReturnsOriginalPlaintext()
+    {
+        // Arrange
+        var key = Enumerable.Range(1, 32).Select(i => (byte)i).ToArray();
+        var crypter = new AesGcmCrypter(key, 16);
+        const string plaintext = "hello";
+
+        // Act
+        var ciphertext = crypter.EncryptValue(plaintext);
+        var decrypted = crypter.DecryptValue(ciphertext);
+
+        // Assert
+        decrypted.Should().Be(plaintext);
+    }
+}

--- a/tests/Aspirate.Tests/SecretTests/SecretProviderTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretProviderTests.cs
@@ -10,7 +10,7 @@ public class SecretProviderTests
     private const string TestKey = "testKey";
     private const string TestResource = "testresource";
     private const string DecryptedTestValue = "testValue";
-    private const string EncryptedTestValue = "dxaPu37gk4KtgYByS0Fyt9hQ/dvbURmdavzyWNs8xEgBdduW9Q==";
+    private const string EncryptedTestValue = "lbD6eicWrRyb6o+4mBDfDUJsrlOR0rstWPfPLr0nAg8OEAer3g==";
     private readonly IFileSystem _fileSystem = CreateMockFilesystem();
 
     [Fact]


### PR DESCRIPTION
## Summary
- add AesGcmCrypterTests covering random nonce generation and decryption
- update SecretProviderTests encrypted value to new format

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6865867f939883319bbd9a1534d0bc3b