### PR TITLE
Add rotate-password command

### DIFF
--- a/docs/Writerside/hi.tree
+++ b/docs/Writerside/hi.tree
@@ -19,6 +19,7 @@
         <toc-element topic="Apply-Manifests.md"/>
         <toc-element topic="Removing-Manifests-from-a-Cluster.md"/>
         <toc-element topic="Non-Interactive-Invocation.md"/>
+        <toc-element topic="Rotate-Password.md"/>
     </toc-element>
     <toc-element topic="Secret-Management.md">
         <toc-element topic="Managing-Secrets.md"/>

--- a/docs/Writerside/topics/Rotate-Password.md
+++ b/docs/Writerside/topics/Rotate-Password.md
@@ -1,0 +1,17 @@
+# Rotating the Password
+
+The `rotate-password` command allows you to change the password used to encrypt secrets stored in `aspirate-state.json`.
+
+When executed, you will be prompted for the current password protecting the secrets. After successful verification, you will be asked to enter a new password twice. All existing secrets will then be re–encrypted using the new password.
+
+```bash
+  aspirate rotate-password
+```
+
+## Cli Options (Optional)
+
+| Option | Alias | Environmental Variable Counterpart | Description |
+|-------|-------|------------------------------------|-------------|
+| --secret-password |       | `ASPIRATE_SECRET_PASSWORD` | Supply the current password when running non‑interactively. |
+| --non-interactive |       | `ASPIRATE_NON_INTERACTIVE` | Disables interactive mode for the command |
+| --disable-secrets |       | `ASPIRATE_DISABLE_SECRETS` | Disables secrets management features. |

--- a/src/Aspirate.Cli/AspirateCli.cs
+++ b/src/Aspirate.Cli/AspirateCli.cs
@@ -66,6 +66,7 @@ internal class AspirateCli : RootCommand
         AddCommand(new BuildCommand());
         AddCommand(new ApplyCommand());
         AddCommand(new DestroyCommand());
+        AddCommand(new RotatePasswordCommand());
         AddCommand(new SettingsCommand());
     }
 }

--- a/src/Aspirate.Cli/GlobalUsings.cs
+++ b/src/Aspirate.Cli/GlobalUsings.cs
@@ -17,6 +17,7 @@ global using Aspirate.Commands.Commands.Destroy;
 global using Aspirate.Commands.Commands.Generate;
 global using Aspirate.Commands.Commands.Init;
 global using Aspirate.Commands.Commands.Run;
+global using Aspirate.Commands.Commands.RotatePassword;
 global using Aspirate.Commands.Commands.Settings;
 global using Aspirate.Commands.Commands.Stop;
 global using Aspirate.Processors;

--- a/src/Aspirate.Commands/Commands/RotatePassword/RotatePasswordCommand.cs
+++ b/src/Aspirate.Commands/Commands/RotatePassword/RotatePasswordCommand.cs
@@ -1,0 +1,11 @@
+namespace Aspirate.Commands.Commands.RotatePassword;
+
+public sealed class RotatePasswordCommand : BaseCommand<RotatePasswordOptions, RotatePasswordCommandHandler>
+{
+    protected override bool CommandUnlocksSecrets => false;
+    protected override bool CommandAlwaysRequiresState => true;
+
+    public RotatePasswordCommand() : base("rotate-password", "Rotates the password protecting secrets")
+    {
+    }
+}

--- a/src/Aspirate.Commands/Commands/RotatePassword/RotatePasswordCommandHandler.cs
+++ b/src/Aspirate.Commands/Commands/RotatePassword/RotatePasswordCommandHandler.cs
@@ -1,0 +1,19 @@
+namespace Aspirate.Commands.Commands.RotatePassword;
+
+public sealed class RotatePasswordCommandHandler(IServiceProvider serviceProvider) : BaseCommandOptionsHandler<RotatePasswordOptions>(serviceProvider)
+{
+    public override Task<int> HandleAsync(RotatePasswordOptions options)
+    {
+        var secretService = Services.GetRequiredService<ISecretService>();
+
+        secretService.RotatePassword(new SecretManagementOptions
+        {
+            State = CurrentState,
+            NonInteractive = options.NonInteractive,
+            DisableSecrets = CurrentState.DisableSecrets,
+            SecretPassword = options.SecretPassword,
+        });
+
+        return Task.FromResult(0);
+    }
+}

--- a/src/Aspirate.Commands/Commands/RotatePassword/RotatePasswordOptions.cs
+++ b/src/Aspirate.Commands/Commands/RotatePassword/RotatePasswordOptions.cs
@@ -1,0 +1,5 @@
+namespace Aspirate.Commands.Commands.RotatePassword;
+
+public sealed class RotatePasswordOptions : BaseCommandOptions
+{
+}

--- a/src/Aspirate.Services/Implementations/SecretService.cs
+++ b/src/Aspirate.Services/Implementations/SecretService.cs
@@ -81,6 +81,41 @@ public class SecretService(
         logger.MarkupLine("[green]Secret State has been initialised![/].");
     }
 
+    public void RotatePassword(SecretManagementOptions options)
+    {
+        if (options.DisableSecrets == true)
+        {
+            logger.MarkupLine("[green]Secrets are disabled[/].");
+            return;
+        }
+
+        if (!secretProvider.SecretStateExists(options.State))
+        {
+            logger.MarkupLine("[red]No secret state exists to rotate.[/]");
+            return;
+        }
+
+        secretProvider.LoadState(options.State);
+
+        if (!CheckPassword(options))
+        {
+            logger.MarkupLine("[red]Aborting due to inability to unlock secrets.[/]");
+            ActionCausesExitException.ExitNow();
+        }
+
+        if (!CreatePassword(options))
+        {
+            logger.ValidationFailed("Aborting due to inability to create password.");
+        }
+
+        secretProvider.RotatePassword(options.SecretPassword!);
+        secretProvider.SetState(options.State);
+        options.State.SecretPassword = options.SecretPassword;
+        options.State.SecretState = secretProvider.State;
+
+        logger.MarkupLine("[green]Secret password rotated![/].");
+    }
+
     public void LoadSecrets(SecretManagementOptions options)
     {
         logger.WriteRuler("[purple]Handling Aspirate Secrets[/]");

--- a/src/Aspirate.Shared/Interfaces/Secrets/ISecretProvider.cs
+++ b/src/Aspirate.Shared/Interfaces/Secrets/ISecretProvider.cs
@@ -15,4 +15,5 @@ public interface ISecretProvider
     string? GetSecret(string resourceName, string key);
     void SetPassword(string password);
     bool CheckPassword(string password);
+    void RotatePassword(string newPassword);
 }

--- a/src/Aspirate.Shared/Interfaces/Services/ISecretService.cs
+++ b/src/Aspirate.Shared/Interfaces/Services/ISecretService.cs
@@ -5,4 +5,5 @@ public interface ISecretService
     void LoadSecrets(SecretManagementOptions options);
     void SaveSecrets(SecretManagementOptions options);
     void ReInitialiseSecrets(SecretManagementOptions options);
+    void RotatePassword(SecretManagementOptions options);
 }

--- a/tests/Aspirate.Tests/SecretTests/SecretProviderTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretProviderTests.cs
@@ -116,6 +116,34 @@ public class SecretProviderTests
         secret.Should().Be(DecryptedTestValue);
     }
 
+    [Fact]
+    public void RotatePassword_ShouldReEncryptSecrets()
+    {
+        var provider = new SecretProvider(_fileSystem);
+
+        var state = GetState(
+            Base64Salt,
+            new Dictionary<string, Dictionary<string, string>>
+            {
+                [TestResource] = new()
+                {
+                    [TestKey] = EncryptedTestValue,
+                },
+            });
+
+        provider.LoadState(state);
+        provider.SetPassword(TestPassword);
+
+        var original = provider.GetSecret(TestResource, TestKey);
+
+        provider.RotatePassword("newPassword");
+
+        provider.CheckPassword("newPassword").Should().BeTrue();
+        var rotated = provider.GetSecret(TestResource, TestKey);
+
+        rotated.Should().Be(original);
+    }
+
     private static AspirateState GetState(string? salt = null, Dictionary<string, Dictionary<string, string>>? secrets = null)
     {
         var state = new SecretState


### PR DESCRIPTION
## Summary
- support rotating the secrets password via new command
- document password rotation
- update interfaces and secret provider
- add unit tests for password rotation

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865899dd8948331b87115211051a4ba