### PR TITLE
Add security docs and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Documentation: https://prom3theu5.github.io/aspirational-manifests/
 9. [Uninstall tool](#uninstall-tool)
 10. [Configuring the Windows Terminal For Unicode and Emoji Support](#configuring-the-windows-terminal-for-unicode-and-emoji-support)
 11. [DevContainer Support](#devcontainer-support)
+12. [Security Best Practices](#security-best-practices)
+13. [Troubleshooting](#troubleshooting)
 
 ## To Install as a global tool
 
@@ -179,3 +181,11 @@ features": {
 ```
 
 An Example of a devcontainer can be found on the documentation page: [Here](https://prom3theu5.github.io/aspirational-manifests/installation-as-a-devcontainer-feature.html#example-dev-container-configuration)
+
+## Security Best Practices
+
+For tips on securing your secrets and state file see the [Security Best Practices](https://prom3theu5.github.io/aspirational-manifests/security-best-practices.html) page.
+
+## Troubleshooting
+
+Common issues and their solutions are available in the [Troubleshooting](https://prom3theu5.github.io/aspirational-manifests/troubleshooting.html) section of the docs.

--- a/docs/Writerside/hi.tree
+++ b/docs/Writerside/hi.tree
@@ -29,4 +29,9 @@
         <toc-element topic="Disable-Secret-Management.md"/>
     </toc-element>
     <toc-element topic="General-FAQ.md"/>
+    <toc-element topic="Configurable-State-Path.md"/>
+    <toc-element topic="File-Permissions.md"/>
+    <toc-element topic="External-Providers.md"/>
+    <toc-element topic="Security-Best-Practices.md"/>
+    <toc-element topic="Troubleshooting.md"/>
 </instance-profile>

--- a/docs/Writerside/topics/Configurable-State-Path.md
+++ b/docs/Writerside/topics/Configurable-State-Path.md
@@ -1,0 +1,5 @@
+# Configurable State Path
+
+By default, aspirate stores the `%state-file%` in the current working directory. Use the `--state-path` option or set the `ASPIRATE_STATE_PATH` environment variable to change this location.
+
+This allows you to keep the state file outside of your project, for example in a secure directory or when running in CI pipelines. Ensure the directory exists before running aspirate.

--- a/docs/Writerside/topics/External-Providers.md
+++ b/docs/Writerside/topics/External-Providers.md
@@ -1,0 +1,7 @@
+# External Providers
+
+Secrets do not have to be stored in the local file provider. Aspir8 supports Azure Key Vault as an alternative backend.
+
+Choose a provider with the `--secret-provider` option or set `ASPIRATE_SECRET_PROVIDER`. When selecting `keyvault` you must also supply the vault name using `--keyvault-name` or `ASPIRATE_KEYVAULT_NAME`.
+
+Using an external provider keeps sensitive values out of the state file and allows shared access between team members.

--- a/docs/Writerside/topics/File-Permissions.md
+++ b/docs/Writerside/topics/File-Permissions.md
@@ -1,0 +1,11 @@
+# File Permissions
+
+Aspir8 writes its state file and generated manifests to disk. Restrict access to these files so only the current user can read them.
+
+On Linux and macOS the recommended permission for `%state-file%` is `600`:
+
+```bash
+chmod 600 %state-file%
+```
+
+Adjust your `umask` or set permissions manually after generation. Windows users should ensure the file is not shared with other accounts.

--- a/docs/Writerside/topics/Security-Best-Practices.md
+++ b/docs/Writerside/topics/Security-Best-Practices.md
@@ -1,0 +1,6 @@
+# Security Best Practices
+
+- Never commit the password used to encrypt secrets.
+- Restrict access to the state file as described in [File Permissions](File-Permissions.md).
+- Rotate your encryption password regularly using the [rotate-password](Rotate-Password.md) command.
+- Prefer an external provider such as Azure Key Vault for shared environments.

--- a/docs/Writerside/topics/Troubleshooting.md
+++ b/docs/Writerside/topics/Troubleshooting.md
@@ -1,0 +1,10 @@
+# Troubleshooting
+
+**Cannot decrypt secrets**
+- Confirm the correct password and verify `ASPIRATE_STATE_PATH` if using a custom location.
+
+**Missing Kubernetes context**
+- Check your kubeconfig and ensure the desired context exists before running `apply`.
+
+**State file not found**
+- Run `generate` to create secrets or verify the state path used by aspirate.


### PR DESCRIPTION
## Summary
- add configurable state path, file permissions, external provider and security docs
- link new pages in Writerside table of contents
- reference security and troubleshooting in README

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68658eadd8748331905dbba7e207fbda