### PR TITLE
Implement configurable state path

### DIFF
--- a/docs/Writerside/topics/Configurable-State-Path.md
+++ b/docs/Writerside/topics/Configurable-State-Path.md
@@ -2,4 +2,16 @@
 
 By default, aspirate stores the `%state-file%` in the current working directory. Use the `--state-path` option or set the `ASPIRATE_STATE_PATH` environment variable to change this location.
 
+For example:
+
+```bash
+aspirate generate --state-path /tmp/aspirate
+```
+
+Or using the environment variable:
+
+```bash
+ASPIRATE_STATE_PATH=/tmp/aspirate aspirate generate
+```
+
 This allows you to keep the state file outside of your project, for example in a secure directory or when running in CI pipelines. Ensure the directory exists before running aspirate.

--- a/src/Aspirate.Commands/Commands/BaseCommand.cs
+++ b/src/Aspirate.Commands/Commands/BaseCommand.cs
@@ -15,6 +15,7 @@ public abstract class BaseCommand<TOptions, TOptionsHandler> : Command
         AddOption(NonInteractiveOption.Instance);
         AddOption(DisableSecretsOption.Instance);
         AddOption(DisableStateOption.Instance);
+        AddOption(StatePathOption.Instance);
         AddOption(LaunchProfileOption.Instance);
         AddOption(SecretProviderOption.Instance);
         Handler = CommandHandler.Create<TOptions, IServiceCollection>(ConstructCommand);
@@ -67,6 +68,7 @@ public abstract class BaseCommand<TOptions, TOptionsHandler> : Command
         {
             NonInteractive = options.NonInteractive,
             DisableState = options.DisableState,
+            StatePath = options.StatePath ?? Directory.GetCurrentDirectory(),
             State = handler.CurrentState,
             RequiresState = requiresState,
         };

--- a/src/Aspirate.Commands/Commands/BaseCommandOptions.cs
+++ b/src/Aspirate.Commands/Commands/BaseCommandOptions.cs
@@ -9,4 +9,5 @@ public abstract class BaseCommandOptions : ICommandOptions
     public string? SecretPassword { get; set; }
     public string? LaunchProfile { get; set; }
     public string? SecretProvider { get; set; }
+    public string? StatePath { get; set; }
 }

--- a/src/Aspirate.Commands/Options/StatePathOption.cs
+++ b/src/Aspirate.Commands/Options/StatePathOption.cs
@@ -1,0 +1,18 @@
+namespace Aspirate.Commands.Options;
+
+public sealed class StatePathOption : BaseOption<string>
+{
+    private static readonly string[] _aliases = ["--state-path"];
+
+    private StatePathOption() : base(_aliases, "ASPIRATE_STATE_PATH", AspirateLiterals.DefaultAspireProjectPath)
+    {
+        Name = nameof(ICommandOptions.StatePath);
+        Description = "The path where the state file will be stored";
+        Arity = ArgumentArity.ExactlyOne;
+        IsRequired = false;
+    }
+
+    public static StatePathOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
+}

--- a/src/Aspirate.Services/Implementations/StateService.cs
+++ b/src/Aspirate.Services/Implementations/StateService.cs
@@ -20,7 +20,7 @@ public class StateService(IFileSystem fs, IAnsiConsole logger, ISecretProvider s
             return;
         }
 
-        var stateFile = fs.Path.Combine(fs.Directory.GetCurrentDirectory(), AspirateLiterals.StateFileName);
+        var stateFile = fs.Path.Combine(options.StatePath, AspirateLiterals.StateFileName);
         var stateAsJson = JsonSerializer.Serialize(options.State, _jsonSerializerOptions);
 
         await fs.File.WriteAllTextAsync(stateFile, stateAsJson);
@@ -76,7 +76,7 @@ public class StateService(IFileSystem fs, IAnsiConsole logger, ISecretProvider s
 
     private bool ShouldCancelAsStateFileDoesNotExist(StateManagementOptions options, out string stateFile)
     {
-        stateFile = fs.Path.Combine(fs.Directory.GetCurrentDirectory(), AspirateLiterals.StateFileName);
+        stateFile = fs.Path.Combine(options.StatePath, AspirateLiterals.StateFileName);
 
         var doesNotExist =  !fs.File.Exists(stateFile);
 

--- a/src/Aspirate.Shared/Inputs/StateManagementOptions.cs
+++ b/src/Aspirate.Shared/Inputs/StateManagementOptions.cs
@@ -6,4 +6,5 @@ public class StateManagementOptions
     public required bool? DisableState { get; set; }
     public required bool? NonInteractive { get; set; } = false;
     public required bool? RequiresState { get; set; } = false;
+    public required string StatePath { get; set; }
 }

--- a/src/Aspirate.Shared/Interfaces/Commands/ICommandOptions.cs
+++ b/src/Aspirate.Shared/Interfaces/Commands/ICommandOptions.cs
@@ -8,4 +8,6 @@ public interface ICommandOptions
     string? SecretPassword { get; set; }
     string? LaunchProfile { get; set; }
     string? SecretProvider { get; set; }
+
+    string? StatePath { get; set; }
 }

--- a/tests/Aspirate.Tests/ServiceTests/StateServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/StateServiceTests.cs
@@ -1,0 +1,78 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Aspirate.Tests.ServiceTests;
+
+public class StateServiceTests : BaseServiceTests<IStateService>
+{
+    [Fact]
+    public async Task SaveState_WritesFile_ToStatePath()
+    {
+        // Arrange
+        var fs = new MockFileSystem();
+        var console = new TestConsole();
+        var secretProvider = new SecretProvider(fs);
+        var sut = new StateService(fs, console, secretProvider);
+
+        var statePath = fs.Path.Combine("/custom", "state");
+        fs.AddDirectory(statePath);
+
+        var state = CreateAspirateState();
+
+        var options = new StateManagementOptions
+        {
+            State = state,
+            DisableState = false,
+            NonInteractive = true,
+            RequiresState = false,
+            StatePath = statePath,
+        };
+
+        // Act
+        await sut.SaveState(options);
+
+        // Assert
+        var stateFile = fs.Path.Combine(statePath, AspirateLiterals.StateFileName);
+        fs.FileExists(stateFile).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RestoreState_ReadsFile_FromStatePath()
+    {
+        // Arrange
+        var fs = new MockFileSystem();
+        var console = new TestConsole();
+        var secretProvider = new SecretProvider(fs);
+        var sut = new StateService(fs, console, secretProvider);
+
+        var statePath = fs.Path.Combine("/custom", "state");
+        fs.AddDirectory(statePath);
+
+        var initialState = CreateAspirateState();
+        var saveOptions = new StateManagementOptions
+        {
+            State = initialState,
+            DisableState = false,
+            NonInteractive = true,
+            RequiresState = false,
+            StatePath = statePath,
+        };
+        await sut.SaveState(saveOptions);
+
+        var newState = CreateAspirateState(projectPath: null);
+        var restoreOptions = new StateManagementOptions
+        {
+            State = newState,
+            DisableState = false,
+            NonInteractive = true,
+            RequiresState = false,
+            StatePath = statePath,
+        };
+
+        // Act
+        await sut.RestoreState(restoreOptions);
+
+        // Assert
+        newState.ProjectPath.Should().Be(initialState.ProjectPath);
+    }
+}


### PR DESCRIPTION
## Summary
- add `StatePathOption` to specify path for state file
- support state path in state service
- track state path in shared options and commands
- document state path usage
- cover new behavior with tests

## Testing
- `dotnet test --no-build` *(fails: The argument /workspace/.../Aspirate.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686591e5116483319e167ac29ebacc71