### PR TITLE
Store secret env files in temp directory

### DIFF
--- a/docs/Writerside/topics/Apply-Manifests.md
+++ b/docs/Writerside/topics/Apply-Manifests.md
@@ -11,6 +11,8 @@ This will be used for deployment
 
 If you have a secret file, you will be prompted to enter the password to decrypt it.
 
+Any secrets are written to temporary files within the operating system's temp directory. These files are created with restricted permissions and are automatically removed after deployment.
+
 ## Cli Options (Optional)
 
 | Option            | Alias | Environmental Variable Counterpart | Description                                                                                         |

--- a/docs/Writerside/topics/Removing-Manifests-from-a-Cluster.md
+++ b/docs/Writerside/topics/Removing-Manifests-from-a-Cluster.md
@@ -11,6 +11,8 @@ This will be used for removal.
 
 If you have a secret file, these secrets will be removed as well. This command does not prompt for a password, as secrets do not need to be decrypted to be removed from your cluster.
 
+Temporary secret files created during deployment are also deleted at this stage.
+
 ## Cli Options (Optional)
 
 | Option            | Alias | Environmental Variable Counterpart | Description                                                                               |


### PR DESCRIPTION
## Summary
- write secret env files to OS temp directory with secure permissions
- document the temp file behaviour in deployment docs

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d2ef2f608331bb82eed023b07c62