### PR TITLE
Add configurable PBKDF2 iterations

### DIFF
--- a/docs/Writerside/topics/Secret-Management.md
+++ b/docs/Writerside/topics/Secret-Management.md
@@ -5,8 +5,16 @@ This feature is designed to increase security and minimize vulnerabilities.
 
 Aspir8 which uses AesGcm encryption to encrypt the secret's file using a password.
 The user supplies this password during the `generate` and `apply` processes.
-It's generated using Pbkdf2 with SHA256, one million iterations, and the hash and salt are stored in the secret file.
+It's generated using Pbkdf2 with SHA256, one million iterations by default, and the hash and salt are stored in the secret file.
 Secrets protected by this provider are only accessible to users who know the password, and are completely safe to store in a Git repository.
+
+The iteration count can be tuned for stronger or faster hashing by setting the `ASPIRATE_PBKDF2_ITERATIONS` environment variable:
+
+```bash
+ASPIRATE_PBKDF2_ITERATIONS=2500000 aspirate generate
+```
+
+If unset, the default value of `1_000_000` iterations is used.
 
 ## Selecting a Secret Provider
 


### PR DESCRIPTION
## Summary
- make PBKDF2 iteration count configurable via `ASPIRATE_PBKDF2_ITERATIONS`
- document iteration configuration in secret management docs
- test that `SecretProvider` honours custom iteration counts

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj` *(fails: NU1603 Azure.Identity 1.10.5 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d9441ff0833187d8f4a5864cf820