### PR TITLE
Handle secret password env var

### DIFF
--- a/docs/Writerside/topics/Secret-Management.md
+++ b/docs/Writerside/topics/Secret-Management.md
@@ -21,3 +21,7 @@ If unset, the default value of `1_000_000` iterations is used.
 Secrets can be stored locally (the default) or in Azure Key Vault. Use the
 `--secret-provider` option or the `ASPIRATE_SECRET_PROVIDER` environment
 variable to choose between `file` and `keyvault` backends.
+
+When supplying the secret password via the `ASPIRATE_SECRET_PASSWORD` environment
+variable, Aspirate clears the variable after reading it to avoid leaving the
+password in the shell environment.

--- a/src/Aspirate.Commands/Options/BaseOption.cs
+++ b/src/Aspirate.Commands/Options/BaseOption.cs
@@ -19,6 +19,10 @@ public abstract class BaseOption<T>(
         () =>
         {
             var envValue = Environment.GetEnvironmentVariable(envVarName);
+            if (envVarName == "ASPIRATE_SECRET_PASSWORD")
+            {
+                Environment.SetEnvironmentVariable(envVarName, null);
+            }
             if (envValue == null)
             {
                 return defaultValue;

--- a/tests/Aspirate.Tests/SecretTests/SecretPasswordOptionTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretPasswordOptionTests.cs
@@ -1,0 +1,24 @@
+using Aspirate.Cli;
+using Aspirate.Commands.Options;
+using System.CommandLine.Parsing;
+using Xunit;
+
+namespace Aspirate.Tests.SecretTests;
+
+public class SecretPasswordOptionTests
+{
+    [Fact]
+    public void ParsingCommand_ClearsSecretPasswordEnvironmentVariable()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("ASPIRATE_SECRET_PASSWORD", "test");
+        var cli = new AspirateCli();
+
+        // Act
+        var result = cli.Parse(["generate"]);
+        result.GetValueForOption(SecretPasswordOption.Instance);
+
+        // Assert
+        Environment.GetEnvironmentVariable("ASPIRATE_SECRET_PASSWORD").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- clear ASPIRATE_SECRET_PASSWORD after it is read
- document that the password environment variable is cleared
- test clearing of the environment variable

## Testing
- `dotnet test` *(fails: NETSDK1045 because the container lacks the .NET 9 SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6865e3f62c888331a664386aea2eb3ed