### PR TITLE
Add API/client secret protectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ aspirate build
 
 Aspirate now includes built-in support for robust secret management, allowing you to easily encrypt sensitive data such as connection strings. This feature is designed to increase security and minimize vulnerabilities.
 
+Built-in protection strategies handle the following configuration keys automatically:
+
+- `ConnectionString*`
+- `POSTGRES_PASSWORD`
+- `MSSQL_SA_PASSWORD`
+- `API_KEY`
+- `CLIENT_SECRET`
+
 ### Managing Secrets
 
 During the `generate` and `apply` processes, you will be prompted to input a password.

--- a/docs/Writerside/topics/Secret-Management.md
+++ b/docs/Writerside/topics/Secret-Management.md
@@ -25,3 +25,13 @@ variable to choose between `file` and `keyvault` backends.
 When supplying the secret password via the `ASPIRATE_SECRET_PASSWORD` environment
 variable, Aspirate clears the variable after reading it to avoid leaving the
 password in the shell environment.
+
+## Built-in Secret Protection Strategies
+
+The following environment variable names are protected automatically when secrets are saved:
+
+- `ConnectionString*` - any value beginning with this prefix.
+- `POSTGRES_PASSWORD`
+- `MSSQL_SA_PASSWORD`
+- `API_KEY`
+- `CLIENT_SECRET`

--- a/src/Aspirate.Secrets/Protectors/ApiKeyProtector.cs
+++ b/src/Aspirate.Secrets/Protectors/ApiKeyProtector.cs
@@ -1,0 +1,29 @@
+namespace Aspirate.Secrets.Protectors;
+
+public class ApiKeyProtector(ISecretProvider secretProvider, IAnsiConsole console) : BaseProtector(secretProvider, console)
+{
+    public override bool HasSecrets(KeyValuePair<string, Resource> component)
+    {
+        if (component.Value is not IResourceWithEnvironmentalVariables componentWithEnv)
+        {
+            return false;
+        }
+
+        return componentWithEnv.Env?.Any(x => x.Key.Equals(ProtectorType.ApiKey.Value, StringComparison.OrdinalIgnoreCase)) ?? false;
+    }
+
+    public override void ProtectSecrets(KeyValuePair<string, Resource> component, bool nonInteractive)
+    {
+        if (component.Value is not IResourceWithEnvironmentalVariables componentWithEnv)
+        {
+            return;
+        }
+
+        var apiKeyInput = componentWithEnv.Env.FirstOrDefault(x => x.Key.Equals(ProtectorType.ApiKey.Value, StringComparison.OrdinalIgnoreCase));
+
+        if (!string.IsNullOrEmpty(apiKeyInput.Key) && apiKeyInput.Key.Equals(ProtectorType.ApiKey.Value, StringComparison.OrdinalIgnoreCase))
+        {
+            UpsertSecret(component, apiKeyInput, nonInteractive);
+        }
+    }
+}

--- a/src/Aspirate.Secrets/Protectors/ClientSecretProtector.cs
+++ b/src/Aspirate.Secrets/Protectors/ClientSecretProtector.cs
@@ -1,0 +1,29 @@
+namespace Aspirate.Secrets.Protectors;
+
+public class ClientSecretProtector(ISecretProvider secretProvider, IAnsiConsole console) : BaseProtector(secretProvider, console)
+{
+    public override bool HasSecrets(KeyValuePair<string, Resource> component)
+    {
+        if (component.Value is not IResourceWithEnvironmentalVariables componentWithEnv)
+        {
+            return false;
+        }
+
+        return componentWithEnv.Env?.Any(x => x.Key.Equals(ProtectorType.ClientSecret.Value, StringComparison.OrdinalIgnoreCase)) ?? false;
+    }
+
+    public override void ProtectSecrets(KeyValuePair<string, Resource> component, bool nonInteractive)
+    {
+        if (component.Value is not IResourceWithEnvironmentalVariables componentWithEnv)
+        {
+            return;
+        }
+
+        var clientSecretInput = componentWithEnv.Env.FirstOrDefault(x => x.Key.Equals(ProtectorType.ClientSecret.Value, StringComparison.OrdinalIgnoreCase));
+
+        if (!string.IsNullOrEmpty(clientSecretInput.Key) && clientSecretInput.Key.Equals(ProtectorType.ClientSecret.Value, StringComparison.OrdinalIgnoreCase))
+        {
+            UpsertSecret(component, clientSecretInput, nonInteractive);
+        }
+    }
+}

--- a/src/Aspirate.Secrets/ServiceCollectionExtensions.cs
+++ b/src/Aspirate.Secrets/ServiceCollectionExtensions.cs
@@ -6,7 +6,9 @@ public static class ServiceCollectionExtensions
         services
             .AddSingleton<ISecretProtectionStrategy, ConnectionStringProtector>()
             .AddSingleton<ISecretProtectionStrategy, PostgresPasswordProtector>()
-            .AddSingleton<ISecretProtectionStrategy, MsSqlPasswordProtector>();
+            .AddSingleton<ISecretProtectionStrategy, MsSqlPasswordProtector>()
+            .AddSingleton<ISecretProtectionStrategy, ApiKeyProtector>()
+            .AddSingleton<ISecretProtectionStrategy, ClientSecretProtector>();
 
     public static IServiceCollection AddAspirateSecretProvider(this IServiceCollection services) =>
         services

--- a/src/Aspirate.Shared/Enums/ProtectorType.cs
+++ b/src/Aspirate.Shared/Enums/ProtectorType.cs
@@ -5,4 +5,6 @@ public class ProtectorType(string name, string value) : SmartEnum<ProtectorType,
     public static readonly ProtectorType ConnectionString = new(nameof(ConnectionString), "ConnectionString");
     public static readonly ProtectorType PostgresPassword = new(nameof(PostgresPassword), "POSTGRES_PASSWORD");
     public static readonly ProtectorType MsSqlPassword = new(nameof(MsSqlPassword), "MSSQL_SA_PASSWORD");
+    public static readonly ProtectorType ApiKey = new(nameof(ApiKey), "API_KEY");
+    public static readonly ProtectorType ClientSecret = new(nameof(ClientSecret), "CLIENT_SECRET");
 }


### PR DESCRIPTION
## Summary
- support API and client secret protection
- register new protectors
- document built-in secret protection strategies

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ec9608348331bb21a6e279895946