### PR TITLE
Add list-secrets command

### DIFF
--- a/src/Aspirate.Cli/AspirateCli.cs
+++ b/src/Aspirate.Cli/AspirateCli.cs
@@ -1,6 +1,7 @@
 using System.CommandLine.Help;
 using Aspirate.Commands.Options;
 using Aspirate.Commands.Commands.ClearSecrets;
+using Aspirate.Commands.Commands.ListSecrets;
 
 namespace Aspirate.Cli;
 
@@ -69,6 +70,7 @@ internal class AspirateCli : RootCommand
         AddCommand(new DestroyCommand());
         AddCommand(new RotatePasswordCommand());
         AddCommand(new ClearSecretsCommand());
+        AddCommand(new ListSecretsCommand());
         AddCommand(new SettingsCommand());
     }
 }

--- a/src/Aspirate.Commands/Commands/ListSecrets/ListSecretsCommand.cs
+++ b/src/Aspirate.Commands/Commands/ListSecrets/ListSecretsCommand.cs
@@ -1,0 +1,13 @@
+namespace Aspirate.Commands.Commands.ListSecrets;
+
+public sealed class ListSecretsCommand : BaseCommand<ListSecretsOptions, ListSecretsCommandHandler>
+{
+    protected override bool CommandUnlocksSecrets => true;
+    protected override bool CommandAlwaysRequiresState => true;
+
+    public ListSecretsCommand() : base("list-secrets", "Lists secret keys per resource")
+    {
+        AddOption(ResourceOption.Instance);
+        AddOption(ProviderOption.Instance);
+    }
+}

--- a/src/Aspirate.Commands/Commands/ListSecrets/ListSecretsCommandHandler.cs
+++ b/src/Aspirate.Commands/Commands/ListSecrets/ListSecretsCommandHandler.cs
@@ -1,0 +1,56 @@
+namespace Aspirate.Commands.Commands.ListSecrets;
+
+public sealed class ListSecretsCommandHandler(IServiceProvider serviceProvider) : BaseCommandOptionsHandler<ListSecretsOptions>(serviceProvider)
+{
+    public override Task<int> HandleAsync(ListSecretsOptions options)
+    {
+        var console = Services.GetRequiredService<IAnsiConsole>();
+        var secretProvider = Services.GetRequiredService<ISecretProvider>();
+
+        if (secretProvider.State?.Secrets == null || secretProvider.State.Secrets.Count == 0)
+        {
+            console.MarkupLine("[yellow]No secrets found.[/]");
+            return Task.FromResult(0);
+        }
+
+        var resources = secretProvider.State.Secrets.AsEnumerable();
+
+        if (!string.IsNullOrEmpty(options.Resource))
+        {
+            resources = resources.Where(r => r.Key.Equals(options.Resource, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(options.Provider))
+        {
+            resources = resources.Where(r =>
+                CurrentState.LoadedAspireManifestResources.TryGetValue(r.Key, out var res) &&
+                res.Type.Equals(options.Provider, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!resources.Any())
+        {
+            console.MarkupLine("[yellow]No matching secrets found.[/]");
+            return Task.FromResult(0);
+        }
+
+        foreach (var resource in resources)
+        {
+            console.MarkupLine($"[underline]{resource.Key}[/]");
+
+            var table = new Table()
+                .AddColumn("Key")
+                .AddColumn("Value");
+
+            foreach (var secret in resource.Value)
+            {
+                var value = secretProvider.GetSecret(resource.Key, secret.Key);
+                var masked = new MaskedValue(value);
+                table.AddRow(secret.Key, masked.ToString());
+            }
+
+            console.Render(table);
+        }
+
+        return Task.FromResult(0);
+    }
+}

--- a/src/Aspirate.Commands/Commands/ListSecrets/ListSecretsOptions.cs
+++ b/src/Aspirate.Commands/Commands/ListSecrets/ListSecretsOptions.cs
@@ -1,0 +1,7 @@
+namespace Aspirate.Commands.Commands.ListSecrets;
+
+public sealed class ListSecretsOptions : BaseCommandOptions, IListSecretsOptions
+{
+    public string? Resource { get; set; }
+    public string? Provider { get; set; }
+}

--- a/src/Aspirate.Commands/Options/ProviderOption.cs
+++ b/src/Aspirate.Commands/Options/ProviderOption.cs
@@ -1,0 +1,18 @@
+namespace Aspirate.Commands.Options;
+
+public sealed class ProviderOption : BaseOption<string?>
+{
+    private static readonly string[] _aliases = ["-p", "--provider"];
+
+    private ProviderOption() : base(_aliases, "ASPIRATE_SECRET_PROVIDER_FILTER", null)
+    {
+        Name = nameof(IListSecretsOptions.Provider);
+        Description = "Filter secrets by resource provider.";
+        Arity = ArgumentArity.ExactlyOne;
+        IsRequired = false;
+    }
+
+    public static ProviderOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
+}

--- a/src/Aspirate.Commands/Options/ResourceOption.cs
+++ b/src/Aspirate.Commands/Options/ResourceOption.cs
@@ -1,0 +1,18 @@
+namespace Aspirate.Commands.Options;
+
+public sealed class ResourceOption : BaseOption<string?>
+{
+    private static readonly string[] _aliases = ["-r", "--resource"];
+
+    private ResourceOption() : base(_aliases, "ASPIRATE_SECRET_RESOURCE", null)
+    {
+        Name = nameof(IListSecretsOptions.Resource);
+        Description = "Filter secrets by resource name.";
+        Arity = ArgumentArity.ExactlyOne;
+        IsRequired = false;
+    }
+
+    public static ResourceOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
+}

--- a/src/Aspirate.Shared/Interfaces/Commands/Contracts/IListSecretsOptions.cs
+++ b/src/Aspirate.Shared/Interfaces/Commands/Contracts/IListSecretsOptions.cs
@@ -1,0 +1,7 @@
+namespace Aspirate.Shared.Interfaces.Commands.Contracts;
+
+public interface IListSecretsOptions
+{
+    string? Resource { get; set; }
+    string? Provider { get; set; }
+}

--- a/tests/Aspirate.Tests/CommandTests/ListSecretsCommandHandlerTests.cs
+++ b/tests/Aspirate.Tests/CommandTests/ListSecretsCommandHandlerTests.cs
@@ -1,0 +1,91 @@
+using Xunit;
+
+namespace Aspirate.Tests.CommandTests;
+
+public class ListSecretsCommandHandlerTests : AspirateTestBase
+{
+    private const string ValidState =
+        """
+        {
+          "salt": "EgEu/M6c1XP/PCkG",
+          "hash": "gSeKYq+cBB8Lx1Fw5iuImcUIONz99cQqt6052BjWLp4\u003d",
+          "secrets": {
+            "postgrescontainer": {
+              "ConnectionString_Test": "EgEu/M6c1XP/PCkGUkJTJ9meX9wOz8mY0w0ca46KF3bVqqHah6QLTDwOyTHX"
+            },
+            "postgrescontainer2": {
+              "ConnectionString_Test": "EgEu/M6c1XP/PCkGUkJTJ9meX9wOz8mY0w0ca46KF3bVqqHah6QLTDwOyTHX"
+            }
+          },
+          "secretsVersion": 1
+        }
+        """;
+
+    [Fact]
+    public async Task HandleAsync_DisplaysSecretsPerResource()
+    {
+        var console = new TestConsole();
+        var fs = new MockFileSystem();
+        var secretProvider = new SecretProvider(fs);
+
+        var state = CreateAspirateStateWithConnectionStrings(nonInteractive: true, password: "password_for_secrets");
+        state.SecretState = JsonSerializer.Deserialize<SecretState>(ValidState);
+        var serviceProvider = CreateServiceProvider(state, console, fs, secretProvider);
+        var secretService = serviceProvider.GetRequiredService<ISecretService>();
+
+        secretService.LoadSecrets(new SecretManagementOptions
+        {
+            State = state,
+            NonInteractive = true,
+            DisableSecrets = false,
+            SecretPassword = state.SecretPassword,
+            SecretProvider = "file",
+        });
+
+        var handler = new ListSecretsCommandHandler(serviceProvider);
+
+        await handler.HandleAsync(new ListSecretsOptions
+        {
+            NonInteractive = true,
+            SecretPassword = "password_for_secrets"
+        });
+
+        console.Output.Should().Contain("postgrescontainer");
+        console.Output.Should().Contain("ConnectionString_Test");
+        console.Output.Should().Contain(new MaskedValue("some_secret_value").ToString());
+    }
+
+    [Fact]
+    public async Task HandleAsync_FilterByResourceName()
+    {
+        var console = new TestConsole();
+        var fs = new MockFileSystem();
+        var secretProvider = new SecretProvider(fs);
+
+        var state = CreateAspirateStateWithConnectionStrings(nonInteractive: true, password: "password_for_secrets");
+        state.SecretState = JsonSerializer.Deserialize<SecretState>(ValidState);
+        var serviceProvider = CreateServiceProvider(state, console, fs, secretProvider);
+        var secretService = serviceProvider.GetRequiredService<ISecretService>();
+
+        secretService.LoadSecrets(new SecretManagementOptions
+        {
+            State = state,
+            NonInteractive = true,
+            DisableSecrets = false,
+            SecretPassword = state.SecretPassword,
+            SecretProvider = "file",
+        });
+
+        var handler = new ListSecretsCommandHandler(serviceProvider);
+
+        await handler.HandleAsync(new ListSecretsOptions
+        {
+            NonInteractive = true,
+            SecretPassword = "password_for_secrets",
+            Resource = "postgrescontainer"
+        });
+
+        console.Output.Should().Contain("postgrescontainer");
+        console.Output.Should().NotContain("postgrescontainer2");
+    }
+}


### PR DESCRIPTION
## Summary
- show secret keys per resource with new `list-secrets` command
- filter results using `--resource` or `--provider`
- wire command into CLI
- test command handler behaviour

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ee3af6188331b03ee65c0a13832a