### PR TITLE
Enforce minimum PBKDF2 iteration count

### DIFF
--- a/src/Aspirate.Secrets/SecretProvider.cs
+++ b/src/Aspirate.Secrets/SecretProvider.cs
@@ -4,7 +4,19 @@ public class SecretProvider(IFileSystem fileSystem) : ISecretProvider
 {
     private const int TagSizeInBytes = 16;
     private const int DefaultIterations = 1_000_000;
-    public int Pbkdf2Iterations { get; set; } = DefaultIterations;
+    private const int MinimumIterations = 100_000;
+
+    private int _pbkdf2Iterations = DefaultIterations;
+    public int Pbkdf2Iterations
+    {
+        get => _pbkdf2Iterations;
+        set => _pbkdf2Iterations = value >= MinimumIterations
+            ? value
+            : throw new ArgumentOutOfRangeException(
+                nameof(Pbkdf2Iterations),
+                value,
+                $"Iterations must be at least {MinimumIterations}");
+    }
     private char[]? _password;
     private IEncrypter? _encrypter;
     private IDecrypter? _decrypter;


### PR DESCRIPTION
## Summary
- enforce minimum iterations in `SecretProvider`
- test minimum iterations and update existing iteration tests

## Testing
- `dotnet test` *(fails: NU1603 and NU1902 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68668c7787648331a277f1eef3f0e957