### PR TITLE
Fix global tool option typo

### DIFF
--- a/docs/Writerside/topics/Installing-as-a-Global-Tool.md
+++ b/docs/Writerside/topics/Installing-as-a-Global-Tool.md
@@ -2,7 +2,7 @@
 
 > **Note**
 >
-> While %product% is in development, the package will be versioned as a preview and the `--prelease` option will get the latest preview.
+> While %product% is in development, the package will be versioned as a preview and the `--prerelease` option will get the latest preview.
 >
 {style="note"}
 


### PR DESCRIPTION
## Summary
- fix prerelease option typo in docs

## Testing
- `dotnet test` *(fails: Azure.Identity 1.10.5 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669194dd5c83318866cbb42152fe10