### PR TITLE
Fix default container builder

### DIFF
--- a/src/Aspirate.Shared/Extensions/AspirateStateExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/AspirateStateExtensions.cs
@@ -31,7 +31,7 @@ public static class AspirateStateExtensions
         // Ensure we have a default container builder.
         if (string.IsNullOrEmpty(state.ContainerBuilder))
         {
-            state.OutputFormat = ContainerBuilder.Docker.Value;
+            state.ContainerBuilder = ContainerBuilder.Docker.Value;
         }
     }
 

--- a/tests/Aspirate.Tests/ExtensionTests/AspirateStateExtensionsTests.cs
+++ b/tests/Aspirate.Tests/ExtensionTests/AspirateStateExtensionsTests.cs
@@ -1,0 +1,45 @@
+using Aspirate.Shared.Enums;
+using Aspirate.Shared.Extensions;
+using Aspirate.Shared.Interfaces.Commands;
+using Aspirate.Shared.Interfaces.Commands.Contracts;
+using Aspirate.Shared.Models.Aspirate;
+using FluentAssertions;
+using Xunit;
+
+namespace Aspirate.Tests.ExtensionTests;
+
+public class AspirateStateExtensionsTests
+{
+    private class TestOptions : ICommandOptions, IContainerOptions
+    {
+        public bool? NonInteractive { get; set; }
+        public bool? DisableSecrets { get; set; }
+        public bool? DisableState { get; set; }
+        public string? SecretPassword { get; set; }
+        public string? LaunchProfile { get; set; }
+        public string? SecretProvider { get; set; }
+        public int? Pbkdf2Iterations { get; set; }
+        public string? StatePath { get; set; }
+
+        public string? ContainerBuilder { get; set; }
+        public string? ContainerBuildContext { get; set; }
+        public string? ContainerRegistry { get; set; }
+        public string? ContainerRepositoryPrefix { get; set; }
+        public List<string>? ContainerImageTags { get; set; }
+        public List<string>? ContainerBuildArgs { get; set; }
+    }
+
+    [Fact]
+    public void PopulateStateFromOptions_SetsDefaultContainerBuilder_WhenNoneProvided()
+    {
+        // Arrange
+        var state = new AspirateState();
+        var options = new TestOptions();
+
+        // Act
+        state.PopulateStateFromOptions(options);
+
+        // Assert
+        state.ContainerBuilder.Should().Be(ContainerBuilder.Docker.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- fix typo in `PopulateStateFromOptions` default ContainerBuilder
- add unit test for `PopulateStateFromOptions`

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build --verbosity minimal` *(fails: Azure.Identity 1.10.5 package missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866919b19408331b8d6be661014ed85