### PR TITLE
Add environment and base64 secret providers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="JsonPath.Net" Version="2.1.0" />
     <PackageVersion Include="KubernetesClient" Version="16.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/docs/Writerside/topics/Clear-Secrets.md
+++ b/docs/Writerside/topics/Clear-Secrets.md
@@ -16,4 +16,4 @@ aspirate clear-secrets
 | --pbkdf2-iterations | | `ASPIRATE_PBKDF2_ITERATIONS` | Override the PBKDF2 iteration count used for password hashing |
 | --state-path | | `ASPIRATE_STATE_PATH` | Path to the directory containing `aspirate-state.json` |
 | --disable-secrets | | `ASPIRATE_DISABLE_SECRETS` | Disables secrets management features. |
-| --secret-provider | | `ASPIRATE_SECRET_PROVIDER` | The secret provider in use. |
+| --secret-provider | | `ASPIRATE_SECRET_PROVIDER` | Secret provider: `file`, `env` or `base64`. |

--- a/docs/Writerside/topics/External-Providers.md
+++ b/docs/Writerside/topics/External-Providers.md
@@ -2,6 +2,13 @@
 
 Secrets do not have to be stored in the local file provider. Aspir8 allows implementing alternative secret backends.
 
-Choose a provider with the `--secret-provider` option or set `ASPIRATE_SECRET_PROVIDER`. The default provider is `file`. Custom providers can be added by extending the service container.
+Choose a provider with the `--secret-provider` option or set `ASPIRATE_SECRET_PROVIDER`.
+Built-in providers are:
+
+- `file` - encrypted secrets stored on disk (default)
+- `env` - secrets supplied via environment variables
+- `base64` - secrets stored as Base64 in the state file
+
+Custom providers can be added by extending the service container.
 
 Using an external provider keeps sensitive values out of the state file and allows shared access between team members.

--- a/docs/Writerside/topics/Generate-Command.md
+++ b/docs/Writerside/topics/Generate-Command.md
@@ -74,7 +74,7 @@ When ran non-interactively, you can specify which components to build with `-c` 
 | --runtime-identifier          |       | `ASPIRATE_RUNTIME_IDENTIFIER`              | Sets the runtime identifier for project builds. Defaults to `linux-x64`.                                                                                                                     |
 | --secret-password             |       | `ASPIRATE_SECRET_PASSWORD`                 | If using secrets, or you have a secret file - Specify the password to decrypt them                                                                                                           |
 | --pbkdf2-iterations             |       | `ASPIRATE_PBKDF2_ITERATIONS`                 | Override the PBKDF2 iteration count used for password hashing
-| --secret-provider             |       | `ASPIRATE_SECRET_PROVIDER`                 | The secret backend provider to use. Defaults to `file`
+| --secret-provider             |       | `ASPIRATE_SECRET_PROVIDER`                 | Secret provider: `file`, `env` or `base64`. Defaults to `file` |
                                     |
 | --non-interactive             |       | `ASPIRATE_NON_INTERACTIVE`                 | Disables interactive mode for the command                                                                                                                                                    |
 | --private-registry            |       | `ASPIRATE_PRIVATE_REGISTRY`                | Enables usage of a private registry - which will produce image pull secret.                                                                                                                  |

--- a/docs/Writerside/topics/Secret-Management.md
+++ b/docs/Writerside/topics/Secret-Management.md
@@ -20,7 +20,12 @@ If unset, the default value of `1_000_000` iterations is used.
 
 Secrets are stored locally by default. Use the
 `--secret-provider` option or the `ASPIRATE_SECRET_PROVIDER` environment
-variable to choose an alternative provider implemented via the service container.
+variable to select a different provider.
+Available providers:
+
+- `file` - encrypted secrets written to disk (default)
+- `env` - read secrets from environment variables
+- `base64` - secrets encoded as Base64 in the state file
 
 When supplying the secret password via the `ASPIRATE_SECRET_PASSWORD` environment
 variable, Aspirate clears the variable after reading it to avoid leaving the

--- a/src/Aspirate.Commands/GlobalUsings.cs
+++ b/src/Aspirate.Commands/GlobalUsings.cs
@@ -14,6 +14,7 @@ global using Aspirate.Processors;
 global using Aspirate.Processors.Resources.AbstractProcessors;
 global using Aspirate.Processors.Resources.Dockerfile;
 global using Aspirate.Processors.Transformation;
+global using Aspirate.Secrets;
 global using Aspirate.Shared.Enums;
 global using Aspirate.Shared.Exceptions;
 global using Aspirate.Shared.Extensions;

--- a/src/Aspirate.Secrets/Aspirate.Secrets.csproj
+++ b/src/Aspirate.Secrets/Aspirate.Secrets.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Aspirate.Shared\Aspirate.Shared.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspirate.Secrets/Base64SecretProvider.cs
+++ b/src/Aspirate.Secrets/Base64SecretProvider.cs
@@ -1,0 +1,72 @@
+namespace Aspirate.Secrets;
+
+public class Base64SecretProvider : ISecretProvider
+{
+    public SecretState? State { get; private set; }
+    public int Pbkdf2Iterations { get; set; }
+
+    public void AddResource(string resourceName)
+    {
+        State ??= new();
+        if (!State.Secrets.ContainsKey(resourceName))
+        {
+            State.Secrets[resourceName] = [];
+        }
+    }
+
+    public bool ResourceExists(string resourceName) => State?.Secrets.ContainsKey(resourceName) == true;
+
+    public void RemoveResource(string resourceName) => State?.Secrets.Remove(resourceName);
+
+    public bool SecretExists(string resourceName, string key) =>
+        State?.Secrets.TryGetValue(resourceName, out var secrets) == true && secrets.ContainsKey(key);
+
+    public void AddSecret(string resourceName, string key, string value)
+    {
+        AddResource(resourceName);
+        State!.Secrets[resourceName][key] = Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+    }
+
+    public void RemoveSecret(string resourceName, string key)
+    {
+        if (State?.Secrets.TryGetValue(resourceName, out var secrets) == true)
+        {
+            secrets.Remove(key);
+        }
+    }
+
+    public void SetState(AspirateState state)
+    {
+        state.SecretState = State;
+    }
+
+    public void LoadState(AspirateState state)
+    {
+        State = state.SecretState ?? new();
+    }
+
+    public void RemoveState(AspirateState state)
+    {
+        State = null;
+        state.SecretState = null;
+    }
+
+    public bool SecretStateExists(AspirateState state) => state.SecretState != null;
+
+    public string? GetSecret(string resourceName, string key)
+    {
+        if (State?.Secrets.TryGetValue(resourceName, out var secrets) == true &&
+            secrets.TryGetValue(key, out var encoded))
+        {
+            return Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+        }
+
+        return null;
+    }
+
+    public void SetPassword(string password) { }
+    public bool CheckPassword(string password) => true;
+    public void RotatePassword(string newPassword) { }
+    public void UpgradeEncryption() { }
+    public void ClearPassword() { }
+}

--- a/src/Aspirate.Secrets/DelegatingSecretProvider.cs
+++ b/src/Aspirate.Secrets/DelegatingSecretProvider.cs
@@ -25,6 +25,7 @@ public class DelegatingSecretProvider(SecretProviderFactory factory, AspirateSta
     public void SetPassword(string password) => Resolve().SetPassword(password);
     public bool CheckPassword(string password) => Resolve().CheckPassword(password);
     public void RotatePassword(string newPassword) => Resolve().RotatePassword(newPassword);
+    public void UpgradeEncryption() => Resolve().UpgradeEncryption();
     public void ClearPassword() => Resolve().ClearPassword();
 }
 

--- a/src/Aspirate.Secrets/EnvironmentSecretProvider.cs
+++ b/src/Aspirate.Secrets/EnvironmentSecretProvider.cs
@@ -1,0 +1,36 @@
+namespace Aspirate.Secrets;
+
+public class EnvironmentSecretProvider : ISecretProvider
+{
+    public SecretState? State { get; private set; }
+    public int Pbkdf2Iterations { get; set; }
+
+    private static string BuildName(string resourceName, string key) => $"{resourceName}_{key}".ToUpperInvariant();
+
+    public void AddResource(string resourceName) { }
+    public bool ResourceExists(string resourceName) => true;
+    public void RemoveResource(string resourceName) { }
+
+    public bool SecretExists(string resourceName, string key) =>
+        Environment.GetEnvironmentVariable(BuildName(resourceName, key)) != null;
+
+    public void AddSecret(string resourceName, string key, string value) =>
+        Environment.SetEnvironmentVariable(BuildName(resourceName, key), value);
+
+    public void RemoveSecret(string resourceName, string key) =>
+        Environment.SetEnvironmentVariable(BuildName(resourceName, key), null);
+
+    public void SetState(AspirateState state) { }
+    public void LoadState(AspirateState state) { }
+    public void RemoveState(AspirateState state) { }
+    public bool SecretStateExists(AspirateState state) => true;
+
+    public string? GetSecret(string resourceName, string key) =>
+        Environment.GetEnvironmentVariable(BuildName(resourceName, key));
+
+    public void SetPassword(string password) { }
+    public bool CheckPassword(string password) => true;
+    public void RotatePassword(string newPassword) { }
+    public void UpgradeEncryption() { }
+    public void ClearPassword() { }
+}

--- a/src/Aspirate.Secrets/SecretProviderFactory.cs
+++ b/src/Aspirate.Secrets/SecretProviderFactory.cs
@@ -7,7 +7,13 @@ public class SecretProviderFactory(IServiceProvider services)
 {
     public ISecretProvider GetProvider(string? provider)
     {
-        return services.GetRequiredService<SecretProvider>();
+        return (provider?.ToLowerInvariant()) switch
+        {
+            null or "" or "file" or "password" => services.GetRequiredService<SecretProvider>(),
+            "env" or "environment" => services.GetRequiredService<EnvironmentSecretProvider>(),
+            "base64" => services.GetRequiredService<Base64SecretProvider>(),
+            _ => throw new InvalidOperationException($"Unknown secret provider '{provider}'.")
+        };
     }
 }
 

--- a/src/Aspirate.Secrets/ServiceCollectionExtensions.cs
+++ b/src/Aspirate.Secrets/ServiceCollectionExtensions.cs
@@ -17,6 +17,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddAspirateSecretProvider(this IServiceCollection services) =>
         services
             .AddSingleton<SecretProvider>()
+            .AddSingleton<Base64SecretProvider>()
+            .AddSingleton<EnvironmentSecretProvider>()
             .AddSingleton<SecretProviderFactory>()
             .AddSingleton<ISecretProvider, DelegatingSecretProvider>();
 }

--- a/src/Aspirate.Services/GlobalUsings.cs
+++ b/src/Aspirate.Services/GlobalUsings.cs
@@ -8,6 +8,7 @@ global using System.Text.Json.Serialization;
 global using System.Text.RegularExpressions;
 global using Ardalis.SmartEnum.SystemTextJson;
 global using Aspirate.Services.Implementations;
+global using Aspirate.Secrets;
 global using Aspirate.Shared.Enums;
 global using Aspirate.Shared.Exceptions;
 global using Aspirate.Shared.Extensions;

--- a/src/Aspirate.Shared/Interfaces/Secrets/ISecretProvider.cs
+++ b/src/Aspirate.Shared/Interfaces/Secrets/ISecretProvider.cs
@@ -17,5 +17,6 @@ public interface ISecretProvider
     void SetPassword(string password);
     bool CheckPassword(string password);
     void RotatePassword(string newPassword);
+    void UpgradeEncryption();
     void ClearPassword();
 }

--- a/tests/Aspirate.Tests/SecretTests/Base64SecretProviderTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/Base64SecretProviderTests.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Aspirate.Tests.SecretTests;
+
+public class Base64SecretProviderTests
+{
+    [Fact]
+    public void AddAndGetSecret_RoundTripsValue()
+    {
+        var provider = new Base64SecretProvider();
+        provider.AddResource("res");
+        provider.AddSecret("res", "key", "value");
+        Assert.Equal("value", provider.GetSecret("res", "key"));
+    }
+}

--- a/tests/Aspirate.Tests/SecretTests/EnvironmentSecretProviderTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/EnvironmentSecretProviderTests.cs
@@ -1,0 +1,23 @@
+using System;
+using Xunit;
+
+namespace Aspirate.Tests.SecretTests;
+
+public class EnvironmentSecretProviderTests
+{
+    [Fact]
+    public void AddSecret_SetsEnvironmentVariable()
+    {
+        var provider = new EnvironmentSecretProvider();
+        provider.AddSecret("res", "key", "value");
+        Assert.Equal("value", Environment.GetEnvironmentVariable("RES_KEY"));
+    }
+
+    [Fact]
+    public void GetSecret_GetsEnvironmentVariable()
+    {
+        Environment.SetEnvironmentVariable("RES_KEY", "value");
+        var provider = new EnvironmentSecretProvider();
+        Assert.Equal("value", provider.GetSecret("res", "key"));
+    }
+}

--- a/tests/Aspirate.Tests/SecretTests/SecretProviderFactoryTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretProviderFactoryTests.cs
@@ -1,0 +1,49 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspirate.Tests.SecretTests;
+
+public class SecretProviderFactoryTests
+{
+    private static ServiceProvider CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<SecretProvider>();
+        services.AddSingleton<Base64SecretProvider>();
+        services.AddSingleton<EnvironmentSecretProvider>();
+        services.AddSingleton<SecretProviderFactory>();
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void GetProvider_File_ReturnsFileProvider()
+    {
+        var factory = CreateServices().GetRequiredService<SecretProviderFactory>();
+        var provider = factory.GetProvider("file");
+        Assert.IsType<SecretProvider>(provider);
+    }
+
+    [Fact]
+    public void GetProvider_Env_ReturnsEnvironmentProvider()
+    {
+        var factory = CreateServices().GetRequiredService<SecretProviderFactory>();
+        var provider = factory.GetProvider("env");
+        Assert.IsType<EnvironmentSecretProvider>(provider);
+    }
+
+    [Fact]
+    public void GetProvider_Base64_ReturnsBase64Provider()
+    {
+        var factory = CreateServices().GetRequiredService<SecretProviderFactory>();
+        var provider = factory.GetProvider("base64");
+        Assert.IsType<Base64SecretProvider>(provider);
+    }
+
+    [Fact]
+    public void GetProvider_Unknown_Throws()
+    {
+        var factory = CreateServices().GetRequiredService<SecretProviderFactory>();
+        Assert.Throws<InvalidOperationException>(() => factory.GetProvider("bad"));
+    }
+}


### PR DESCRIPTION
## Summary
- add EnvironmentSecretProvider and Base64SecretProvider implementations
- resolve secret provider names via `SecretProviderFactory`
- register new providers in dependency injection
- document provider options and update CLI docs
- test factory resolution and provider behaviors

## Testing
- `dotnet build Aspirate.sln` *(fails: MaskedValue type errors and CA1416 warnings)*
- `dotnet test --no-build` *(fails: invalid argument error)*

------
https://chatgpt.com/codex/tasks/task_e_6866a7fef6c48331bba9cf263a3326be