### PR TITLE
Persist PBKDF2 iteration count

### DIFF
--- a/docs/Writerside/topics/Secret-Management.md
+++ b/docs/Writerside/topics/Secret-Management.md
@@ -16,6 +16,8 @@ ASPIRATE_PBKDF2_ITERATIONS=2500000 aspirate generate
 
 If unset, the default value of `1_000_000` iterations is used.
 
+The chosen iteration count is saved in the secrets file so subsequent runs use the same value automatically.
+
 ## Selecting a Secret Provider
 
 Secrets are stored locally by default. Use the

--- a/docs/Writerside/topics/Secrets-File-Contents.md
+++ b/docs/Writerside/topics/Secrets-File-Contents.md
@@ -6,6 +6,7 @@ An example of the contents of secrets within the state file are shown below:
 {
   "salt": "2hO/L8lfSH6BG5J1",
   "hash": "4nLU37zidTC1TF6EM8h6\u002BIz79wIu03nYAIiMhuIKcwU=",
+  "pbkdf2Iterations": 1000000,
   "secrets": {
     "catalogservice": {
       "ConnectionStrings__catalogdb": "2hO/L8lfSH6BG5J1YKAxbgV8Jkg33lnuKqrPD5/kCk\u002BJZRhJz33KFWZnLIEL2P2Z52M3Nf3K55RUctdzR4rVtovBFtFJLqO4cCDXc2\u002BEleXzyn48vdEOJ37tmU1V0VLGPzFYsGjHV3DQ"
@@ -27,6 +28,8 @@ An example of the contents of secrets within the state file are shown below:
 The `salt` and `hash` properties are used to encrypt the secrets in the `secrets` property.
 
 Each individual secret is encrypted using the `AesGcm` algorithm, using the `salt` and `hash` properties as the key.
+
+`pbkdf2Iterations` stores the number of PBKDF2 rounds used to derive the encryption key.
 
 The `secretsVersion` value denotes the encryption algorithm in use. When Aspirate upgrades the algorithm this number increases, signalling that stored secrets should be re-encrypted.
 

--- a/src/Aspirate.Secrets/SecretProvider.cs
+++ b/src/Aspirate.Secrets/SecretProvider.cs
@@ -3,7 +3,7 @@ namespace Aspirate.Secrets;
 public class SecretProvider(IFileSystem fileSystem) : ISecretProvider
 {
     private const int TagSizeInBytes = 16;
-    private const int DefaultIterations = 1_000_000;
+    private const int DefaultIterations = SecretState.DefaultIterations;
     private const int MinimumIterations = 100_000;
 
     private int _pbkdf2Iterations = DefaultIterations;
@@ -56,6 +56,10 @@ public class SecretProvider(IFileSystem fileSystem) : ISecretProvider
         }
 
         SetPasswordHash();
+        if (State is not null)
+        {
+            State.Pbkdf2Iterations = Pbkdf2Iterations;
+        }
     }
 
     public bool CheckPassword(string password)
@@ -81,6 +85,7 @@ public class SecretProvider(IFileSystem fileSystem) : ISecretProvider
         }
 
         _salt = !string.IsNullOrEmpty(State.Salt) ? Convert.FromBase64String(State.Salt) : null;
+        Pbkdf2Iterations = State.Pbkdf2Iterations > 0 ? State.Pbkdf2Iterations : DefaultIterations;
     }
 
     private void CreateNewSalt()
@@ -93,6 +98,7 @@ public class SecretProvider(IFileSystem fileSystem) : ISecretProvider
             State.SecretsVersion = SecretState.CurrentVersion;
         }
         State.Salt = Convert.ToBase64String(_salt);
+        State.Pbkdf2Iterations = Pbkdf2Iterations;
     }
 
     private void SetPasswordHash()

--- a/src/Aspirate.Services/Implementations/SecretService.cs
+++ b/src/Aspirate.Services/Implementations/SecretService.cs
@@ -13,7 +13,9 @@ public class SecretService(
     private ISecretProvider GetProvider(SecretManagementOptions options)
     {
         var provider = _factory.GetProvider(options.SecretProvider ?? options.State.SecretProvider);
-        provider.Pbkdf2Iterations = options.Pbkdf2Iterations ?? provider.Pbkdf2Iterations;
+        provider.Pbkdf2Iterations = options.Pbkdf2Iterations
+            ?? options.State.SecretState?.Pbkdf2Iterations
+            ?? provider.Pbkdf2Iterations;
         return provider;
     }
 
@@ -53,6 +55,10 @@ public class SecretService(
         if (secretProvider.SecretStateExists(options.State))
         {
             secretProvider.LoadState(options.State);
+            if (secretProvider.State is not null)
+            {
+                secretProvider.Pbkdf2Iterations = secretProvider.State.Pbkdf2Iterations;
+            }
             versionMismatch = CheckSecretVersion(secretProvider);
 
             if (!CheckPassword(options))
@@ -64,6 +70,10 @@ public class SecretService(
             if (versionMismatch && logger.Confirm("Re-encrypt secrets using the new algorithm?"))
             {
                 secretProvider.UpgradeEncryption();
+                if (secretProvider.State is not null)
+                {
+                    secretProvider.State.Pbkdf2Iterations = secretProvider.Pbkdf2Iterations;
+                }
                 secretProvider.SetState(options.State);
             }
         }
@@ -91,6 +101,10 @@ public class SecretService(
             }
         }
 
+        if (secretProvider.State is not null)
+        {
+            secretProvider.State.Pbkdf2Iterations = secretProvider.Pbkdf2Iterations;
+        }
         secretProvider.SetState(options.State);
 
         logger.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Secret State has been saved.");
@@ -110,6 +124,10 @@ public class SecretService(
 
         HandleInitialisation(options);
 
+        if (secretProvider.State is not null)
+        {
+            secretProvider.State.Pbkdf2Iterations = secretProvider.Pbkdf2Iterations;
+        }
         secretProvider.SetState(options.State);
 
         options.State.SecretState = secretProvider.State;
@@ -134,6 +152,10 @@ public class SecretService(
         }
 
         secretProvider.LoadState(options.State);
+        if (secretProvider.State is not null)
+        {
+            secretProvider.Pbkdf2Iterations = secretProvider.State.Pbkdf2Iterations;
+        }
         var versionMismatch = CheckSecretVersion(secretProvider);
 
         if (!CheckPassword(options))
@@ -145,6 +167,10 @@ public class SecretService(
         if (versionMismatch && logger.Confirm("Re-encrypt secrets using the new algorithm?"))
         {
             secretProvider.UpgradeEncryption();
+            if (secretProvider.State is not null)
+            {
+                secretProvider.State.Pbkdf2Iterations = secretProvider.Pbkdf2Iterations;
+            }
             secretProvider.SetState(options.State);
         }
 
@@ -154,6 +180,10 @@ public class SecretService(
         }
 
         secretProvider.RotatePassword(options.SecretPassword!);
+        if (secretProvider.State is not null)
+        {
+            secretProvider.State.Pbkdf2Iterations = secretProvider.Pbkdf2Iterations;
+        }
         secretProvider.SetState(options.State);
         options.State.SecretPassword = options.SecretPassword;
         options.State.SecretState = secretProvider.State;
@@ -186,6 +216,10 @@ public class SecretService(
         }
 
         secretProvider.LoadState(options.State);
+        if (secretProvider.State is not null)
+        {
+            secretProvider.Pbkdf2Iterations = secretProvider.State.Pbkdf2Iterations;
+        }
         var versionMismatch = CheckSecretVersion(secretProvider);
 
         if (!options.CommandUnlocksSecrets)

--- a/src/Aspirate.Shared/Models/Aspirate/SecretState.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/SecretState.cs
@@ -2,7 +2,12 @@ namespace Aspirate.Shared.Models.Aspirate;
 
 public sealed class SecretState
 {
-public const int CurrentVersion = 2;
+    public const int CurrentVersion = 2;
+
+    /// <summary>
+    /// Default PBKDF2 iteration count used when none is specified.
+    /// </summary>
+    public const int DefaultIterations = 1_000_000;
 
     [JsonPropertyName("salt")]
     [RestorableStateProperty]
@@ -11,6 +16,10 @@ public const int CurrentVersion = 2;
     [JsonPropertyName("hash")]
     [RestorableStateProperty]
     public string? Hash { get; set; }
+
+    [JsonPropertyName("pbkdf2Iterations")]
+    [RestorableStateProperty]
+    public int Pbkdf2Iterations { get; set; } = DefaultIterations;
 
     [JsonPropertyName("secrets")]
     [RestorableStateProperty]

--- a/tests/Aspirate.Tests/SecretTests/SecretProviderTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretProviderTests.cs
@@ -184,6 +184,22 @@ public class SecretProviderTests
         rotated.Should().Be(original);
     }
 
+    [Fact]
+    public void IterationCount_PersistedAcrossLoad()
+    {
+        var provider = new SecretProvider(_fileSystem) { Pbkdf2Iterations = 150_000 };
+        var state = GetState(Base64Salt);
+        provider.LoadState(state);
+        provider.SetPassword(TestPassword);
+        provider.SetState(state);
+
+        var provider2 = new SecretProvider(_fileSystem);
+        provider2.LoadState(state);
+
+        provider2.Pbkdf2Iterations.Should().Be(150_000);
+        provider2.CheckPassword(TestPassword).Should().BeTrue();
+    }
+
     private static AspirateState GetState(string? salt = null, Dictionary<string, Dictionary<string, string>>? secrets = null)
     {
         var state = new SecretState


### PR DESCRIPTION
## Summary
- add `Pbkdf2Iterations` to `SecretState`
- store iterations in `SecretProvider`
- sync iteration count in `SecretService`
- check iteration persistence in tests
- document iteration count field

## Testing
- `dotnet test` *(fails: ListSecretsCommandHandlerTests.cs missing types)*

------
https://chatgpt.com/codex/tasks/task_e_6866aef18fb48331aadc32bad5216db7