### PR TITLE
Add async SecretService methods

### DIFF
--- a/src/Aspirate.Commands/Actions/Secrets/SaveSecretsAction.cs
+++ b/src/Aspirate.Commands/Actions/Secrets/SaveSecretsAction.cs
@@ -5,11 +5,11 @@ public class SaveSecretsAction(
     ISecretService secretService,
     IServiceProvider serviceProvider) : BaseAction(serviceProvider)
 {
-    public override Task<bool> ExecuteAsync()
+    public override async Task<bool> ExecuteAsync()
     {
         Logger.WriteRuler("[purple]Populating Secrets File[/]");
 
-        secretService.SaveSecrets(new SecretManagementOptions
+        await secretService.SaveSecretsAsync(new SecretManagementOptions
         {
             State = CurrentState,
             NonInteractive = CurrentState.NonInteractive,
@@ -18,6 +18,6 @@ public class SaveSecretsAction(
             SecretProvider = CurrentState.SecretProvider,
         });
 
-        return Task.FromResult(true);
+        return true;
     }
 }

--- a/src/Aspirate.Commands/Commands/BaseCommand.cs
+++ b/src/Aspirate.Commands/Commands/BaseCommand.cs
@@ -44,7 +44,7 @@ public abstract class BaseCommand<TOptions, TOptionsHandler> : Command
 
         handler.CurrentState.PopulateStateFromOptions(options);
 
-        LoadSecrets(options, secretService, handler);
+        await LoadSecrets(options, secretService, handler);
 
         var exitCode = await handler.HandleAsync(options);
 
@@ -53,8 +53,8 @@ public abstract class BaseCommand<TOptions, TOptionsHandler> : Command
         return exitCode;
     }
 
-    private void LoadSecrets(TOptions options, ISecretService secretService, TOptionsHandler handler) =>
-        secretService.LoadSecrets(new SecretManagementOptions
+    private Task LoadSecrets(TOptions options, ISecretService secretService, TOptionsHandler handler) =>
+        secretService.LoadSecretsAsync(new SecretManagementOptions
         {
             DisableSecrets = handler.CurrentState.DisableSecrets,
             NonInteractive = options.NonInteractive,

--- a/src/Aspirate.Commands/Commands/ClearSecrets/ClearSecretsCommandHandler.cs
+++ b/src/Aspirate.Commands/Commands/ClearSecrets/ClearSecretsCommandHandler.cs
@@ -2,11 +2,11 @@ namespace Aspirate.Commands.Commands.ClearSecrets;
 
 public sealed class ClearSecretsCommandHandler(IServiceProvider serviceProvider) : BaseCommandOptionsHandler<ClearSecretsOptions>(serviceProvider)
 {
-    public override Task<int> HandleAsync(ClearSecretsOptions options)
+    public override async Task<int> HandleAsync(ClearSecretsOptions options)
     {
         var secretService = Services.GetRequiredService<ISecretService>();
 
-        secretService.ClearSecrets(new SecretManagementOptions
+        await secretService.ClearSecretsAsync(new SecretManagementOptions
         {
             State = CurrentState,
             NonInteractive = options.NonInteractive,
@@ -18,6 +18,6 @@ public sealed class ClearSecretsCommandHandler(IServiceProvider serviceProvider)
             Force = options.Force
         });
 
-        return Task.FromResult(0);
+        return 0;
     }
 }

--- a/src/Aspirate.Commands/Commands/RotatePassword/RotatePasswordCommandHandler.cs
+++ b/src/Aspirate.Commands/Commands/RotatePassword/RotatePasswordCommandHandler.cs
@@ -2,11 +2,11 @@ namespace Aspirate.Commands.Commands.RotatePassword;
 
 public sealed class RotatePasswordCommandHandler(IServiceProvider serviceProvider) : BaseCommandOptionsHandler<RotatePasswordOptions>(serviceProvider)
 {
-    public override Task<int> HandleAsync(RotatePasswordOptions options)
+    public override async Task<int> HandleAsync(RotatePasswordOptions options)
     {
         var secretService = Services.GetRequiredService<ISecretService>();
 
-        secretService.RotatePassword(new SecretManagementOptions
+        await secretService.RotatePasswordAsync(new SecretManagementOptions
         {
             State = CurrentState,
             NonInteractive = options.NonInteractive,
@@ -16,6 +16,6 @@ public sealed class RotatePasswordCommandHandler(IServiceProvider serviceProvide
             Pbkdf2Iterations = options.Pbkdf2Iterations,
         });
 
-        return Task.FromResult(0);
+        return 0;
     }
 }

--- a/src/Aspirate.Shared/Interfaces/Services/ISecretService.cs
+++ b/src/Aspirate.Shared/Interfaces/Services/ISecretService.cs
@@ -3,8 +3,13 @@ namespace Aspirate.Shared.Interfaces.Services;
 public interface ISecretService
 {
     void LoadSecrets(SecretManagementOptions options);
+    Task LoadSecretsAsync(SecretManagementOptions options);
     void SaveSecrets(SecretManagementOptions options);
+    Task SaveSecretsAsync(SecretManagementOptions options);
     void ReInitialiseSecrets(SecretManagementOptions options);
+    Task ReInitialiseSecretsAsync(SecretManagementOptions options);
     void RotatePassword(SecretManagementOptions options);
+    Task RotatePasswordAsync(SecretManagementOptions options);
     void ClearSecrets(SecretManagementOptions options);
+    Task ClearSecretsAsync(SecretManagementOptions options);
 }


### PR DESCRIPTION
## Summary
- introduce asynchronous methods in `ISecretService`
- implement async operations in `SecretService`
- update commands to use async secret management
- extend secret service tests with async variants

## Testing
- `dotnet test` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6866b37492f083319ee446c24238c213