### PR TITLE
Update final manifest private registry handling

### DIFF
--- a/src/Aspirate.Processors/FinalProcessor.cs
+++ b/src/Aspirate.Processors/FinalProcessor.cs
@@ -52,10 +52,7 @@ public sealed class FinalProcessor(IFileSystem fileSystem, IAnsiConsole console,
             return;
         }
 
-        _console.MarkupLine("[bold]Generating private registry secret manifest.[/]");
-        _manifestWriter.CreateImagePullSecret(registryUrl, registryUsername, registryPassword, registryEmail, TemplateLiterals.ImagePullSecretType, outputPath);
-        manifests.Add($"{TemplateLiterals.ImagePullSecretType}.yaml");
-        _console.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Generating [blue]{outputPath}/{TemplateLiterals.ImagePullSecretType}.yaml[/]");
+        _console.MarkupLine("[bold]Private registry detected. Image pull secret will be generated dynamically during deployment.[/]");
     }
 
     private void HandleNamespace(string outputPath, string? templatePath, string @namespace, KubernetesDeploymentData templateDataBuilder, List<string> manifests)


### PR DESCRIPTION
## Summary
- avoid creating an image pull secret in `FinalProcessor`

## Testing
- `dotnet test -v minimal` *(fails: `IKubeCtlService` missing method `ApplyManifestFile`)*

------
https://chatgpt.com/codex/tasks/task_e_68673f70aee0833194232bcd5add21d2