### PR TITLE
Add temp file writer for image pull secret

### DIFF
--- a/src/Aspirate.Shared/Interfaces/Services/IKubeCtlService.cs
+++ b/src/Aspirate.Shared/Interfaces/Services/IKubeCtlService.cs
@@ -43,4 +43,12 @@ public interface IKubeCtlService
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.
     /// The task result represents whether the manifests were successfully removed.</returns>
     Task<bool> RemoveManifests(string context, string outputFolder);
+
+    /// <summary>
+    /// Applies an individual manifest file to the specified context.
+    /// </summary>
+    /// <param name="context">The kubernetes context.</param>
+    /// <param name="manifestFile">The manifest file to apply.</param>
+    /// <returns>A task representing whether the apply succeeded.</returns>
+    Task<bool> ApplyManifestFile(string context, string manifestFile);
 }

--- a/src/Aspirate.Shared/Interfaces/Services/IKustomizeService.cs
+++ b/src/Aspirate.Shared/Interfaces/Services/IKustomizeService.cs
@@ -4,6 +4,7 @@ public interface IKustomizeService
 {
     Task<string> RenderManifestUsingKustomize(string kustomizePath);
     Task WriteSecretsOutToTempFiles(AspirateState state, List<string> files, ISecretProvider secretProvider);
+    Task<string?> WriteImagePullSecretToTempFile(AspirateState state, ISecretProvider provider);
     void CleanupSecretEnvFiles(bool? disableSecrets, IEnumerable<string> secretFiles);
     CommandAvailableResult IsKustomizeAvailable();
 }


### PR DESCRIPTION
## Summary
- extend `IKustomizeService` with `WriteImagePullSecretToTempFile`
- implement image pull secret writing in `KustomizeService`
- expose `ApplyManifestFile` on `IKubeCtlService`
- test writing image pull secret to a temp file

## Testing
- `dotnet build` *(fails: extension method must be defined in a non-generic static class)*
- `dotnet test` *(fails: IKubeCtlService does not contain definition for ApplyManifestFile)*

------
https://chatgpt.com/codex/tasks/task_e_686740e7286883319fcc829a868815a8