### PR TITLE
Update ApplyManifests action

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/ApplyManifestsToClusterAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ApplyManifestsToClusterAction.cs
@@ -22,6 +22,15 @@ public sealed class ApplyManifestsToClusterAction(
             await HandleDapr();
 
             await kustomizeService.WriteSecretsOutToTempFiles(CurrentState, secretFiles, secretProvider);
+
+            var imagePullSecretFile = await kustomizeService.WriteImagePullSecretToTempFile(CurrentState, secretProvider);
+
+            if (!string.IsNullOrEmpty(imagePullSecretFile))
+            {
+                secretFiles.Add(imagePullSecretFile);
+                await kubeCtlService.ApplyManifestFile(CurrentState.KubeContext, imagePullSecretFile);
+            }
+
             await kubeCtlService.ApplyManifests(CurrentState.KubeContext, CurrentState.InputPath);
             await HandleRollingRestart();
             Logger.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done:[/] Deployments successfully applied to cluster [blue]'{CurrentState.KubeContext}'[/]");


### PR DESCRIPTION
## Summary
- ensure private registry secret is applied before manifests
- test that secret is applied and cleaned up properly

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674899becc833198d9955ccca074b3