### PR TITLE
Add image pull secret YAML generation method

### DIFF
--- a/src/Aspirate.Services/Implementations/ManifestWriter.cs
+++ b/src/Aspirate.Services/Implementations/ManifestWriter.cs
@@ -125,6 +125,14 @@ public class ManifestWriter(IFileSystem fileSystem) : IManifestWriter
     /// <inheritdoc />
     public void CreateImagePullSecret(string registryUrl, string registryUsername, string registryPassword, string registryEmail, string secretName, string outputPath)
     {
+        var secretYaml = CreateImagePullSecretYaml(registryUrl, registryUsername, registryPassword, registryEmail, secretName);
+
+        fileSystem.File.WriteAllText(fileSystem.Path.Combine(outputPath, $"{TemplateLiterals.ImagePullSecretType}.yaml"), secretYaml);
+    }
+
+    /// <inheritdoc />
+    public string CreateImagePullSecretYaml(string registryUrl, string registryUsername, string registryPassword, string registryEmail, string secretName)
+    {
         var dockerConfigJson = CreateDockerConfigJson(registryUrl, registryUsername, registryPassword, registryEmail);
 
         var secret = ImagePullSecret.Create()
@@ -135,9 +143,7 @@ public class ManifestWriter(IFileSystem fileSystem) : IManifestWriter
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .Build();
 
-        string secretYaml = serializer.Serialize(secret);
-
-        fileSystem.File.WriteAllText(fileSystem.Path.Combine(outputPath, $"{TemplateLiterals.ImagePullSecretType}.yaml"), secretYaml);
+        return serializer.Serialize(secret);
     }
 
     private void CreateFile<TTemplateData>(string inputFile, string outputPath, TTemplateData data, string? templatePath)

--- a/src/Aspirate.Shared/Interfaces/Services/IManifestWriter.cs
+++ b/src/Aspirate.Shared/Interfaces/Services/IManifestWriter.cs
@@ -85,6 +85,17 @@ public interface IManifestWriter
     void CreateImagePullSecret(string registryUrl, string registryUsername, string registryPassword, string registryEmail, string secretName, string outputPath);
 
     /// <summary>
+    /// Creates the YAML string for an image pull secret.
+    /// </summary>
+    /// <param name="registryUrl">The URL of the container registry.</param>
+    /// <param name="registryUsername">The username to authenticate with the registry.</param>
+    /// <param name="registryPassword">The password to authenticate with the registry.</param>
+    /// <param name="registryEmail">The email associated with the registry.</param>
+    /// <param name="secretName">The name of the secret.</param>
+    /// <returns>The YAML representation of the secret.</returns>
+    string CreateImagePullSecretYaml(string registryUrl, string registryUsername, string registryPassword, string registryEmail, string secretName);
+
+    /// <summary>
     /// Create a custom manifest file using the specified parameters.
     /// </summary>
     /// <param name="outputPath">The output path of the manifest file.</param>

--- a/tests/Aspirate.Tests/ServiceTests/KustomizeServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/KustomizeServiceTests.cs
@@ -15,7 +15,8 @@ public class KustomizeServiceTests : AspirateTestBase
 
         var shellExecutionService = Substitute.For<IShellExecutionService>();
         var console = Substitute.For<IAnsiConsole>();
-        var sut = new KustomizeService(fs, shellExecutionService, console);
+        var manifestWriter = new ManifestWriter(fs);
+        var sut = new KustomizeService(fs, shellExecutionService, console, manifestWriter);
 
         var state = CreateAspirateStateWithConnectionStrings();
         state.SecretState = new SecretState
@@ -54,7 +55,8 @@ public class KustomizeServiceTests : AspirateTestBase
 
         var shellExecutionService = Substitute.For<IShellExecutionService>();
         var console = Substitute.For<IAnsiConsole>();
-        var sut = new KustomizeService(fs, shellExecutionService, console);
+        var manifestWriter = new ManifestWriter(fs);
+        var sut = new KustomizeService(fs, shellExecutionService, console, manifestWriter);
 
         var state = CreateAspirateState();
         state.WithPrivateRegistry = true;


### PR DESCRIPTION
## Summary
- add `CreateImagePullSecretYaml` to `ManifestWriter` and expose via `IManifestWriter`
- refactor `CreateImagePullSecret` and `KustomizeService` to use the new helper
- inject `IManifestWriter` in `KustomizeService`
- update tests for new dependency

## Testing
- `dotnet build src/Aspirate.Processors/Aspirate.Processors.csproj /p:LangVersion=preview` *(fails: Extension method must be defined in a non-generic static class)*

------
https://chatgpt.com/codex/tasks/task_e_68674bf55f288331b4627575b064946a