### PR TITLE
Fix extension method errors

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -50,7 +50,9 @@ public class ConfigureIngressAction(
             foreach (var service in selected)
             {
                 var host = Logger.Ask<string>($"[bold]Enter host for service [blue]{service}[/]: [/]");
-                var tls = Logger.Ask<string>($"[bold]Enter TLS secret for service [blue]{service}[/] (leave blank if none): [/]", "");
+                var tls = Logger.Prompt(
+                    new TextPrompt<string>($"[bold]Enter TLS secret for service [blue]{service}[/] (leave blank if none): [/]")
+                        .AllowEmpty());
                 CurrentState.IngressDefinitions[service] = new IngressDefinition
                 {
                     Host = host,


### PR DESCRIPTION
## Summary
- fix ApplyIngress extension methods by turning them into local helpers
- allow empty TLS input when configuring ingress

## Testing
- `dotnet build Aspirate.sln -c Debug --no-restore` *(fails: Aspirate.Tests did not build)*
- `dotnet test Aspirate.sln -c Debug --no-build` *(fails to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_686750952a54833187c4fc702c1a95f2