### PR TITLE
Fix build by adding missing usings

### DIFF
--- a/tests/Aspirate.Tests/ActionsTests/Manifests/ApplyManifestsToClusterActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Manifests/ApplyManifestsToClusterActionTests.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Threading.Tasks;
+using Aspirate.Cli;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace Aspirate.Tests.ActionsTests.Manifests;

--- a/tests/Aspirate.Tests/CommandTests/ListSecretsCommandHandlerTests.cs
+++ b/tests/Aspirate.Tests/CommandTests/ListSecretsCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Aspirate.Commands.Commands.ListSecrets;
 using Xunit;
 
 namespace Aspirate.Tests.CommandTests;

--- a/tests/Aspirate.Tests/CommandTests/VerifySecretsCommandHandlerTests.cs
+++ b/tests/Aspirate.Tests/CommandTests/VerifySecretsCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Aspirate.Commands.Commands.VerifySecrets;
 using Xunit;
 
 namespace Aspirate.Tests.CommandTests;

--- a/tests/Aspirate.Tests/SecretTests/SecretPasswordOptionTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretPasswordOptionTests.cs
@@ -1,5 +1,6 @@
 using Aspirate.Cli;
 using Aspirate.Commands.Options;
+using System.CommandLine;
 using System.CommandLine.Parsing;
 using Xunit;
 

--- a/tests/Aspirate.Tests/ServiceTests/KubernetesIngressServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/KubernetesIngressServiceTests.cs
@@ -1,4 +1,6 @@
 using System.Threading.Tasks;
+using k8s;
+using k8s.Models;
 using Xunit;
 
 namespace Aspirate.Tests.ServiceTests;

--- a/tests/Aspirate.Tests/ServiceTests/StateServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/StateServiceTests.cs
@@ -106,6 +106,7 @@ public class StateServiceTests : BaseServiceTests<IStateService>
 
         if (OperatingSystem.IsWindows())
         {
+#pragma warning disable CA1416 // Validate platform compatibility
             var fileInfo = fs.FileInfo.New(stateFile);
             var acl = fileInfo.GetAccessControl();
             var rules = acl.GetAccessRules(true, true, typeof(SecurityIdentifier)).Cast<FileSystemAccessRule>();
@@ -113,6 +114,7 @@ public class StateServiceTests : BaseServiceTests<IStateService>
             rules.Should().Contain(r => r.IdentityReference.Equals(currentUser) &&
                                        r.FileSystemRights.HasFlag(FileSystemRights.Read) &&
                                        r.FileSystemRights.HasFlag(FileSystemRights.Write));
+#pragma warning restore CA1416
         }
         else
         {


### PR DESCRIPTION
## Summary
- add missing namespaces to test files
- suppress CA1416 warnings for permission checks

## Testing
- `dotnet build Aspirate.sln -c Debug`
- `dotnet test Aspirate.sln -c Debug --no-build` *(fails: Failed!  - Failed:    26, Passed:   183, Skipped:     0)*

------
https://chatgpt.com/codex/tasks/task_e_6867527dfb948331b5a25898ab710964