### PR TITLE
Attempt test fixes

### DIFF
--- a/tests/Aspirate.Tests/ActionsTests/Configuration/InitializeConfigurationActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Configuration/InitializeConfigurationActionTests.cs
@@ -16,7 +16,7 @@ public class InitializeConfigurationActionTests : BaseActionTests<InitializeConf
         var initializeConfigurationAction = GetSystemUnderTest(serviceProvider);
 
         // Act
-        var act = () => initializeConfigurationAction.ValidateNonInteractiveState();
+        var act = initializeConfigurationAction.ValidateNonInteractiveState;
 
         // Assert
         act.Should().Throw<ActionCausesExitException>();
@@ -31,7 +31,7 @@ public class InitializeConfigurationActionTests : BaseActionTests<InitializeConf
         var loadConfigurationAction = GetSystemUnderTest(serviceProvider);
 
         // Act
-        var act = () => loadConfigurationAction.ValidateNonInteractiveState();
+        var act = loadConfigurationAction.ValidateNonInteractiveState;
 
         // Assert
         act.Should().Throw<ActionCausesExitException>();
@@ -46,7 +46,7 @@ public class InitializeConfigurationActionTests : BaseActionTests<InitializeConf
         var initializeConfigurationAction = GetSystemUnderTest(serviceProvider);
 
         // Act
-        var act = () => initializeConfigurationAction.ValidateNonInteractiveState();
+        var act = initializeConfigurationAction.ValidateNonInteractiveState;
 
         // Assert
         act.Should().Throw<ActionCausesExitException>();
@@ -63,7 +63,7 @@ public class InitializeConfigurationActionTests : BaseActionTests<InitializeConf
         var initializeConfigurationAction = GetSystemUnderTest(serviceProvider);
 
         // Act
-        var act = () => initializeConfigurationAction.ValidateNonInteractiveState();
+        var act = initializeConfigurationAction.ValidateNonInteractiveState;
 
         // Assert
         act.Should().NotThrow<ActionCausesExitException>();
@@ -99,6 +99,7 @@ public class InitializeConfigurationActionTests : BaseActionTests<InitializeConf
         result.Should().BeTrue();
         var aspirateSettingsJson = await fileSystem.File.ReadAllTextAsync(fileSystem.Path.Combine(DefaultProjectPath, AspirateSettings.FileName));
         var aspirateSettings = JsonSerializer.Deserialize<AspirateSettings>(aspirateSettingsJson);
+        aspirateSettings.TemplatePath = aspirateSettings.TemplatePath.Replace("\\", "/");
         await Verify(aspirateSettings)
             .UseDirectory("VerifyResults");
     }

--- a/tests/Aspirate.Tests/SecretTests/SecretProviderFactoryTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretProviderFactoryTests.cs
@@ -9,6 +9,7 @@ public class SecretProviderFactoryTests
     private static ServiceProvider CreateServices()
     {
         var services = new ServiceCollection();
+        services.AddSingleton<IFileSystem, FileSystem>();
         services.AddSingleton<SecretProvider>();
         services.AddSingleton<Base64SecretProvider>();
         services.AddSingleton<EnvironmentSecretProvider>();

--- a/tests/Aspirate.Tests/ServiceTests/KustomizeServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/KustomizeServiceTests.cs
@@ -10,8 +10,8 @@ public class KustomizeServiceTests : AspirateTestBase
     public async Task WriteSecretsOutToTempFiles_AndCleanupSecretEnvFiles_WorkTogether()
     {
         // Arrange
-        var fs = new MockFileSystem();
-        fs.AddDirectory(fs.Path.GetTempPath());
+        var fs = new FileSystem();
+        fs.Directory.CreateDirectory(fs.Path.GetTempPath());
 
         var shellExecutionService = Substitute.For<IShellExecutionService>();
         var console = Substitute.For<IAnsiConsole>();
@@ -50,8 +50,8 @@ public class KustomizeServiceTests : AspirateTestBase
     [Fact]
     public async Task WriteImagePullSecretToTempFile_CreatesFile()
     {
-        var fs = new MockFileSystem();
-        fs.AddDirectory(fs.Path.GetTempPath());
+        var fs = new FileSystem();
+        fs.Directory.CreateDirectory(fs.Path.GetTempPath());
 
         var shellExecutionService = Substitute.For<IShellExecutionService>();
         var console = Substitute.For<IAnsiConsole>();

--- a/tests/Aspirate.Tests/ServiceTests/StateServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/StateServiceTests.cs
@@ -1,7 +1,8 @@
-using System.Threading.Tasks;
+using System;
+using System.Linq;
 using System.Security.AccessControl;
 using System.Security.Principal;
-using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Aspirate.Tests.ServiceTests;
@@ -12,13 +13,13 @@ public class StateServiceTests : BaseServiceTests<IStateService>
     public async Task SaveState_WritesFile_ToStatePath()
     {
         // Arrange
-        var fs = new MockFileSystem();
+        var fs = new FileSystem();
         var console = new TestConsole();
         var secretProvider = new SecretProvider(fs);
         var sut = new StateService(fs, console, secretProvider);
 
-        var statePath = fs.Path.Combine("/custom", "state");
-        fs.AddDirectory(statePath);
+        var statePath = fs.Path.Combine(fs.Path.GetTempPath(), Guid.NewGuid().ToString());
+        fs.Directory.CreateDirectory(statePath);
 
         var state = CreateAspirateState();
 
@@ -43,13 +44,13 @@ public class StateServiceTests : BaseServiceTests<IStateService>
     public async Task RestoreState_ReadsFile_FromStatePath()
     {
         // Arrange
-        var fs = new MockFileSystem();
+        var fs = new FileSystem();
         var console = new TestConsole();
         var secretProvider = new SecretProvider(fs);
         var sut = new StateService(fs, console, secretProvider);
 
-        var statePath = fs.Path.Combine("/custom", "state");
-        fs.AddDirectory(statePath);
+        var statePath = fs.Path.Combine(fs.Path.GetTempPath(), Guid.NewGuid().ToString());
+        fs.Directory.CreateDirectory(statePath);
 
         var initialState = CreateAspirateState();
         var saveOptions = new StateManagementOptions
@@ -82,13 +83,13 @@ public class StateServiceTests : BaseServiceTests<IStateService>
     [Fact]
     public async Task SaveState_SetsSecurePermissions()
     {
-        var fs = new MockFileSystem(new Dictionary<string, MockFileData>(), "/");
+        var fs = new FileSystem();
         var console = new TestConsole();
         var secretProvider = new SecretProvider(fs);
         var sut = new StateService(fs, console, secretProvider);
 
-        var statePath = "/state";
-        fs.AddDirectory(statePath);
+        var statePath = fs.Path.Combine(fs.Path.GetTempPath(), Guid.NewGuid().ToString());
+        fs.Directory.CreateDirectory(statePath);
 
         var state = CreateAspirateState();
         var options = new StateManagementOptions


### PR DESCRIPTION
## Summary
- register FileSystem for SecretProviderFactory tests
- adjust Unix permission tests to use FileSystem
- fix platform path issue in InitializeConfigurationAction

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build --verbosity quiet` *(fails: 26 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6867575cd5b483319eb3196321176c42