### PR TITLE
Attempt to fix build and tests

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -49,8 +49,14 @@ public class ConfigureIngressAction(
 
             foreach (var service in selected)
             {
-                var host = Logger.Ask<string>($"[bold]Enter host for service [blue]{service}[/]: [/]");
-                var tls = Logger.Ask<string>($"[bold]Enter TLS secret for service [blue]{service}[/] (leave blank if none): [/]", "");
+                var host = Logger.Prompt(
+                    new TextPrompt<string>($"[bold]Enter host for service [blue]{service}[/]: [/]")
+                        .PromptStyle("yellow"));
+
+                var tls = Logger.Prompt(
+                    new TextPrompt<string>($"[bold]Enter TLS secret for service [blue]{service}[/] (leave blank if none): [/]")
+                        .PromptStyle("yellow")
+                        .AllowEmpty());
                 CurrentState.IngressDefinitions[service] = new IngressDefinition
                 {
                     Host = host,

--- a/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
@@ -184,18 +184,4 @@ public abstract class BaseContainerProcessor<TContainerResource>(
         return data.ToKubernetesObjects(options.EncodeSecrets);
     }
 
-    private static KubernetesDeploymentData ApplyIngress(this KubernetesDeploymentData data, BaseKubernetesCreateOptions options)
-    {
-        var state = options.CurrentState;
-        if (state?.IngressDefinitions != null && state.IngressDefinitions.TryGetValue(options.Resource.Key, out var def))
-        {
-            data
-                .SetIngressEnabled(true)
-                .SetIngressHost(def.Host)
-                .SetIngressTlsSecret(def.TlsSecret)
-                .SetIngressPath(def.Path);
-        }
-
-        return data;
-    }
 }

--- a/src/Aspirate.Processors/Resources/Project/BaseProjectProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Project/BaseProjectProcessor.cs
@@ -154,18 +154,4 @@ public abstract class BaseProjectProcessor(
         return data.ToKubernetesObjects(options.EncodeSecrets);
     }
 
-    private static KubernetesDeploymentData ApplyIngress(this KubernetesDeploymentData data, BaseKubernetesCreateOptions options)
-    {
-        var state = options.CurrentState;
-        if (state?.IngressDefinitions != null && state.IngressDefinitions.TryGetValue(options.Resource.Key, out var def))
-        {
-            data
-                .SetIngressEnabled(true)
-                .SetIngressHost(def.Host)
-                .SetIngressTlsSecret(def.TlsSecret)
-                .SetIngressPath(def.Path);
-        }
-
-        return data;
-    }
 }

--- a/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
@@ -366,4 +366,19 @@ public static class KubernetesDeploymentDataExtensions
             });
         }
     }
+
+    public static KubernetesDeploymentData ApplyIngress(this KubernetesDeploymentData data, BaseKubernetesCreateOptions options)
+    {
+        var state = options.CurrentState;
+        if (state?.IngressDefinitions != null && state.IngressDefinitions.TryGetValue(options.Resource.Key, out var def))
+        {
+            data
+                .SetIngressEnabled(true)
+                .SetIngressHost(def.Host)
+                .SetIngressTlsSecret(def.TlsSecret)
+                .SetIngressPath(def.Path);
+        }
+
+        return data;
+    }
 }

--- a/tests/Aspirate.Tests/ActionsTests/Manifests/ApplyManifestsToClusterActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Manifests/ApplyManifestsToClusterActionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Aspirate.Cli;
 using Xunit;
 
 namespace Aspirate.Tests.ActionsTests.Manifests;

--- a/tests/Aspirate.Tests/Aspirate.Tests.csproj
+++ b/tests/Aspirate.Tests/Aspirate.Tests.csproj
@@ -19,10 +19,15 @@
         <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
     </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <ProjectReference Include="..\..\src\Aspirate.Cli\Aspirate.Cli.csproj" />
       <ProjectReference Include="..\..\src\Aspirate.Secrets\Aspirate.Secrets.csproj" />
-    </ItemGroup>
+      <ProjectReference Include="..\..\src\Aspirate.Commands\Aspirate.Commands.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+      <PackageReference Include="KubernetesClient" />
+  </ItemGroup>
 
     <ItemGroup>
       <Compile Remove="TestData\**" />

--- a/tests/Aspirate.Tests/CommandTests/ListSecretsCommandHandlerTests.cs
+++ b/tests/Aspirate.Tests/CommandTests/ListSecretsCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Aspirate.Commands.Commands.ListSecrets;
 using Xunit;
 
 namespace Aspirate.Tests.CommandTests;

--- a/tests/Aspirate.Tests/CommandTests/VerifySecretsCommandHandlerTests.cs
+++ b/tests/Aspirate.Tests/CommandTests/VerifySecretsCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Aspirate.Commands.Commands.VerifySecrets;
 using Xunit;
 
 namespace Aspirate.Tests.CommandTests;

--- a/tests/Aspirate.Tests/SecretTests/SecretPasswordOptionTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretPasswordOptionTests.cs
@@ -1,5 +1,6 @@
 using Aspirate.Cli;
 using Aspirate.Commands.Options;
+using System.CommandLine;
 using System.CommandLine.Parsing;
 using Xunit;
 

--- a/tests/Aspirate.Tests/SecretTests/SecretProviderFactoryTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretProviderFactoryTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using System.IO.Abstractions;
 using Xunit;
 
 namespace Aspirate.Tests.SecretTests;
@@ -9,6 +10,7 @@ public class SecretProviderFactoryTests
     private static ServiceProvider CreateServices()
     {
         var services = new ServiceCollection();
+        services.AddSingleton<IFileSystem>(new FileSystem());
         services.AddSingleton<SecretProvider>();
         services.AddSingleton<Base64SecretProvider>();
         services.AddSingleton<EnvironmentSecretProvider>();

--- a/tests/Aspirate.Tests/ServiceTests/KubernetesIngressServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/KubernetesIngressServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using k8s;
 using Xunit;
 
 namespace Aspirate.Tests.ServiceTests;


### PR DESCRIPTION
## Summary
- add extension method ApplyIngress
- fix container processor classes to use new extension
- rewrite ConfigureIngressAction prompts
- reference commands and KubernetesClient packages for tests
- update tests for proper namespaces and real filesystem usage

## Testing
- `dotnet build tests/Aspirate.Tests/Aspirate.Tests.csproj -v minimal`
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build -v minimal` *(fails: NotImplementedException in MockFile)*

------
https://chatgpt.com/codex/tasks/task_e_68675c4d67108331bebc7c8d6546a0ae