### PR TITLE
Fix path in initialization test

### DIFF
--- a/tests/Aspirate.Tests/ActionsTests/Configuration/InitializeConfigurationActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Configuration/InitializeConfigurationActionTests.cs
@@ -99,6 +99,11 @@ public class InitializeConfigurationActionTests : BaseActionTests<InitializeConf
         result.Should().BeTrue();
         var aspirateSettingsJson = await fileSystem.File.ReadAllTextAsync(fileSystem.Path.Combine(DefaultProjectPath, AspirateSettings.FileName));
         var aspirateSettings = JsonSerializer.Deserialize<AspirateSettings>(aspirateSettingsJson);
+
+        // Normalize the template path for cross platform consistency
+        var templateFolderName = fileSystem.Path.GetFileName(aspirateSettings.TemplatePath);
+        aspirateSettings.TemplatePath = $"/{templateFolderName}";
+
         await Verify(aspirateSettings)
             .UseDirectory("VerifyResults");
     }


### PR DESCRIPTION
## Summary
- normalize template path in `InitializeConfigurationActionTests.ExecuteInitializeConfigurationAction_InteractiveMode_Success` test for consistent results on Windows and Unix

## Testing
- `dotnet test --filter "InitializeConfigurationActionTests.ExecuteInitializeConfigurationAction_InteractiveMode_Success"`

------
https://chatgpt.com/codex/tasks/task_e_686763d5d4a48331bdd8d59c84ca63fb