### PR TITLE
Fix test secret state and enable unlocking

### DIFF
--- a/tests/Aspirate.Tests/ActionsTests/Secrets/SaveSecretsActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Secrets/SaveSecretsActionTests.cs
@@ -13,13 +13,14 @@ public class SaveSecretsActionTests : BaseActionTests<SaveSecretsAction>
           "hash": "gSeKYq+cBB8Lx1Fw5iuImcUIONz99cQqt6052BjWLp4\u003d",
           "secrets": {
             "postgrescontainer": {
-              "ConnectionString_Test": "EgEu/M6c1XP/PCkGUkJTJ9meX9wOz8mY0w0ca46KF3bVqqHah6QLTDwOyTHX"
+              "ConnectionString_Test": "pS2TKkcv5CsdOmBrZoNrxebeFYacDs2LM+QDGtYvHLIJPJ6JO6y2XUk4GULsVGYS"
             },
             "postgrescontainer2": {
-              "ConnectionString_Test": "EgEu/M6c1XP/PCkGUkJTJ9meX9wOz8mY0w0ca46KF3bVqqHah6QLTDwOyTHX"
+              "ConnectionString_Test": "pS2TKkcv5CsdOmBrZoNrxebeFYacDs2LM+QDGtYvHLIJPJ6JO6y2XUk4GULsVGYS"
             }
           },
-          "secretsVersion": 2
+          "secretsVersion": 2,
+          "pbkdf2Iterations": 1000000
         }
         """;
 

--- a/tests/Aspirate.Tests/CommandTests/ListSecretsCommandHandlerTests.cs
+++ b/tests/Aspirate.Tests/CommandTests/ListSecretsCommandHandlerTests.cs
@@ -12,13 +12,14 @@ public class ListSecretsCommandHandlerTests : AspirateTestBase
           "hash": "gSeKYq+cBB8Lx1Fw5iuImcUIONz99cQqt6052BjWLp4\u003d",
           "secrets": {
             "postgrescontainer": {
-              "ConnectionString_Test": "EgEu/M6c1XP/PCkGUkJTJ9meX9wOz8mY0w0ca46KF3bVqqHah6QLTDwOyTHX"
+              "ConnectionString_Test": "pS2TKkcv5CsdOmBrZoNrxebeFYacDs2LM+QDGtYvHLIJPJ6JO6y2XUk4GULsVGYS"
             },
             "postgrescontainer2": {
-              "ConnectionString_Test": "EgEu/M6c1XP/PCkGUkJTJ9meX9wOz8mY0w0ca46KF3bVqqHah6QLTDwOyTHX"
+              "ConnectionString_Test": "pS2TKkcv5CsdOmBrZoNrxebeFYacDs2LM+QDGtYvHLIJPJ6JO6y2XUk4GULsVGYS"
             }
           },
-          "secretsVersion": 2
+          "secretsVersion": 2,
+          "pbkdf2Iterations": 1000000
         }
         """;
 
@@ -41,6 +42,7 @@ public class ListSecretsCommandHandlerTests : AspirateTestBase
             DisableSecrets = false,
             SecretPassword = state.SecretPassword,
             SecretProvider = "file",
+            CommandUnlocksSecrets = true,
         });
 
         var handler = new ListSecretsCommandHandler(serviceProvider);
@@ -75,6 +77,7 @@ public class ListSecretsCommandHandlerTests : AspirateTestBase
             DisableSecrets = false,
             SecretPassword = state.SecretPassword,
             SecretProvider = "file",
+            CommandUnlocksSecrets = true,
         });
 
         var handler = new ListSecretsCommandHandler(serviceProvider);

--- a/tests/Aspirate.Tests/CommandTests/VerifySecretsCommandHandlerTests.cs
+++ b/tests/Aspirate.Tests/CommandTests/VerifySecretsCommandHandlerTests.cs
@@ -12,10 +12,11 @@ public class VerifySecretsCommandHandlerTests : AspirateTestBase
           "hash": "gSeKYq+cBB8Lx1Fw5iuImcUIONz99cQqt6052BjWLp4\u003d",
           "secrets": {
             "postgrescontainer": {
-              "ConnectionString_Test": "EgEu/M6c1XP/PCkGUkJTJ9meX9wOz8mY0w0ca46KF3bVqqHah6QLTDwOyTHX"
+              "ConnectionString_Test": "pS2TKkcv5CsdOmBrZoNrxebeFYacDs2LM+QDGtYvHLIJPJ6JO6y2XUk4GULsVGYS"
             }
           },
-          "secretsVersion": 2
+          "secretsVersion": 2,
+          "pbkdf2Iterations": 1000000
         }
         """;
 

--- a/tests/Aspirate.Tests/ServiceTests/SecretServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/SecretServiceTests.cs
@@ -12,13 +12,14 @@ public class SecretServiceTests : BaseServiceTests<ISecretService>
           "hash": "gSeKYq+cBB8Lx1Fw5iuImcUIONz99cQqt6052BjWLp4\u003d",
           "secrets": {
             "postgrescontainer": {
-              "ConnectionString_Test": "EgEu/M6c1XP/PCkGUkJTJ9meX9wOz8mY0w0ca46KF3bVqqHah6QLTDwOyTHX"
+              "ConnectionString_Test": "pS2TKkcv5CsdOmBrZoNrxebeFYacDs2LM+QDGtYvHLIJPJ6JO6y2XUk4GULsVGYS"
             },
             "postgrescontainer2": {
-              "ConnectionString_Test": "EgEu/M6c1XP/PCkGUkJTJ9meX9wOz8mY0w0ca46KF3bVqqHah6QLTDwOyTHX"
+              "ConnectionString_Test": "pS2TKkcv5CsdOmBrZoNrxebeFYacDs2LM+QDGtYvHLIJPJ6JO6y2XUk4GULsVGYS"
             }
           },
-          "secretsVersion": 2
+          "secretsVersion": 2,
+          "pbkdf2Iterations": 1000000
         }
         """;
 


### PR DESCRIPTION
## Summary
- fix tests by unlocking secrets during setup
- update test secret state data to match new encryption

## Testing
- `dotnet test --filter FullyQualifiedName~ListSecretsCommandHandlerTests.HandleAsync_DisplaysSecretsPerResource` *(fails: Expected console.Output "── Handling Aspirate Secrets ───────────────────────────────────────────────────(✔) Done:  Secret State populated successfully.
No secrets found." to contain "postgrescontainer".)*

------
https://chatgpt.com/codex/tasks/task_e_686769000054833188c7d7cf4a8d9620