### PR TITLE
Fix secret provider tests

### DIFF
--- a/src/Aspirate.Secrets/SecretProvider.cs
+++ b/src/Aspirate.Secrets/SecretProvider.cs
@@ -85,7 +85,11 @@ public class SecretProvider(IFileSystem fileSystem) : ISecretProvider
         }
 
         _salt = !string.IsNullOrEmpty(State.Salt) ? Convert.FromBase64String(State.Salt) : null;
-        Pbkdf2Iterations = State.Pbkdf2Iterations > 0 ? State.Pbkdf2Iterations : DefaultIterations;
+
+        if (_pbkdf2Iterations == DefaultIterations)
+        {
+            Pbkdf2Iterations = State.Pbkdf2Iterations > 0 ? State.Pbkdf2Iterations : DefaultIterations;
+        }
     }
 
     private void CreateNewSalt()

--- a/src/Aspirate.Services/Implementations/SecretService.cs
+++ b/src/Aspirate.Services/Implementations/SecretService.cs
@@ -55,7 +55,8 @@ public class SecretService(
             return;
         }
 
-        if (!ProtectionStrategies.CheckForProtectableSecrets(options.State.AllSelectedSupportedComponents))
+        if (!ProtectionStrategies.CheckForProtectableSecrets(options.State.AllSelectedSupportedComponents)
+            && options.State.WithPrivateRegistry != true)
         {
             logger.MarkupLine("No secrets to protect in any [blue]selected components[/]");
             return;

--- a/tests/Aspirate.Tests/SecretTests/SecretProviderTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretProviderTests.cs
@@ -139,13 +139,16 @@ public class SecretProviderTests
         var provider = new SecretProvider(_fileSystem);
 
         var state = GetState(
-            Base64Salt, secrets: new()
+            Base64Salt,
+            secrets: new()
             {
                 [TestResource] = new()
                 {
                     [TestKey] = EncryptedTestValue,
                 },
-            });
+            },
+            pbkdf2Iterations: 1_000_000,
+            secretsVersion: 1);
 
         provider.LoadState(state);
 
@@ -169,7 +172,9 @@ public class SecretProviderTests
                 {
                     [TestKey] = EncryptedTestValue,
                 },
-            });
+            },
+            pbkdf2Iterations: 1_000_000,
+            secretsVersion: 1);
 
         provider.LoadState(state);
         provider.SetPassword(TestPassword);
@@ -200,12 +205,18 @@ public class SecretProviderTests
         provider2.CheckPassword(TestPassword).Should().BeTrue();
     }
 
-    private static AspirateState GetState(string? salt = null, Dictionary<string, Dictionary<string, string>>? secrets = null)
+    private static AspirateState GetState(
+        string? salt = null,
+        Dictionary<string, Dictionary<string, string>>? secrets = null,
+        int? pbkdf2Iterations = null,
+        int secretsVersion = SecretState.CurrentVersion)
     {
         var state = new SecretState
         {
             Salt = salt,
             Secrets = secrets ?? [],
+            Pbkdf2Iterations = pbkdf2Iterations ?? SecretState.DefaultIterations,
+            SecretsVersion = secretsVersion,
         };
 
         return new AspirateState { SecretState = state };


### PR DESCRIPTION
## Summary
- preserve custom PBKDF2 iteration count during state restoration
- ensure SaveSecrets handles registry-only secrets
- extend test helper to specify secret version

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build --filter "FullyQualifiedName~SecretProviderTests" --logger "console;verbosity=normal" --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68677367adac833182ef2fc3a38dbb10