### PR TITLE
Fix Kubernetes ingress service test

### DIFF
--- a/tests/Aspirate.Tests/ServiceTests/KubernetesIngressServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/KubernetesIngressServiceTests.cs
@@ -1,5 +1,8 @@
 using System.Threading.Tasks;
+using System.Threading;
+using System.Collections.Generic;
 using k8s;
+using k8s.Autorest;
 using Xunit;
 
 namespace Aspirate.Tests.ServiceTests;
@@ -15,7 +18,13 @@ public class KubernetesIngressServiceTests : BaseServiceTests<IKubernetesIngress
         var console = Substitute.For<IAnsiConsole>();
         var k8sClient = Substitute.For<IKubernetes>();
         k8sService.CreateClient("test").Returns(k8sClient);
-        k8sClient.CoreV1.ReadNamespaceAsync("ingress-nginx").Returns(Task.FromException<V1Namespace>(new Exception()));
+        k8sClient.CoreV1
+            .ReadNamespaceWithHttpMessagesAsync(
+                "ingress-nginx",
+                Arg.Any<bool?>(),
+                Arg.Any<IReadOnlyDictionary<string, IReadOnlyList<string>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<HttpOperationResponse<V1Namespace>>(new Exception()));
 
         var sut = new KubernetesIngressService(fileSystem, kubeCtl, k8sService, console);
 


### PR DESCRIPTION
## Summary
- adjust mocking for Kubernetes ingress test to work with k8s client

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --filter FullyQualifiedName~KubernetesIngressServiceTests.EnsureIngressController_InstallsController_WhenMissing --verbosity minimal`
- `dotnet test --no-build --verbosity minimal` *(fails: MockFile.SetUnixFileMode not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68678c97580c8331b182ac811e0a571c