### PR TITLE
Fix Kubernetes ingress service test

### DIFF
--- a/tests/Aspirate.Tests/ServiceTests/KubernetesIngressServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/KubernetesIngressServiceTests.cs
@@ -1,5 +1,8 @@
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using k8s;
+using k8s.Autorest;
 using Xunit;
 
 namespace Aspirate.Tests.ServiceTests;
@@ -15,7 +18,13 @@ public class KubernetesIngressServiceTests : BaseServiceTests<IKubernetesIngress
         var console = Substitute.For<IAnsiConsole>();
         var k8sClient = Substitute.For<IKubernetes>();
         k8sService.CreateClient("test").Returns(k8sClient);
-        k8sClient.CoreV1.ReadNamespaceAsync("ingress-nginx").Returns(Task.FromException<V1Namespace>(new Exception()));
+        k8sClient.CoreV1
+            .ReadNamespaceWithHttpMessagesAsync(
+                "ingress-nginx",
+                Arg.Any<bool?>(),
+                Arg.Any<IReadOnlyDictionary<string, IReadOnlyList<string>>>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpOperationException());
 
         var sut = new KubernetesIngressService(fileSystem, kubeCtl, k8sService, console);
 


### PR DESCRIPTION
## Summary
- fix ingress service test to mock underlying HTTP call

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj -c Release --no-build --filter FullyQualifiedName~KubernetesIngressServiceTests`

------
https://chatgpt.com/codex/tasks/task_e_68678c97580c8331b182ac811e0a571c