### PR TITLE
Add executable resource processor

### DIFF
--- a/src/Aspirate.Processors/GlobalUsings.cs
+++ b/src/Aspirate.Processors/GlobalUsings.cs
@@ -7,6 +7,7 @@ global using Aspirate.Processors.Resources.AbstractProcessors;
 global using Aspirate.Processors.Resources.Dapr;
 global using Aspirate.Processors.Resources.Dockerfile;
 global using Aspirate.Processors.Resources.Project;
+global using Aspirate.Processors.Resources.Executable;
 global using Aspirate.Processors.Transformation.Bindings;
 global using Aspirate.Processors.Transformation.Json;
 global using Aspirate.Secrets.Protectors;

--- a/src/Aspirate.Processors/Resources/Executable/ExecutableProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Executable/ExecutableProcessor.cs
@@ -1,0 +1,65 @@
+namespace Aspirate.Processors.Resources.Executable;
+
+public class ExecutableProcessor(
+    IFileSystem fileSystem,
+    IAnsiConsole console,
+    IManifestWriter manifestWriter)
+    : BaseResourceProcessor(fileSystem, console, manifestWriter)
+{
+    public override string ResourceType => AspireComponentLiterals.Executable;
+
+    public override Resource? Deserialize(ref Utf8JsonReader reader) =>
+        JsonSerializer.Deserialize<ExecutableResource>(ref reader);
+
+    public override Task<bool> CreateManifests(CreateManifestsOptions options) =>
+        // Executable resources do not generate additional manifests.
+        Task.FromResult(true);
+
+    public override ComposeService CreateComposeEntry(CreateComposeEntryOptions options)
+    {
+        var exec = options.Resource.Value as ExecutableResource;
+
+        var commands = new List<string>();
+        if (!string.IsNullOrEmpty(exec?.Command))
+        {
+            commands.Add(exec.Command);
+        }
+        if (exec?.Args != null)
+        {
+            commands.AddRange(exec.Args);
+        }
+
+        var serviceBuilder = Builder.MakeService(options.Resource.Key)
+            .WithImage("busybox:latest")
+            .WithEnvironment(options.Resource.MapResourceToEnvVars(options.WithDashboard))
+            .WithContainerName(options.Resource.Key)
+            .WithPortMappings(options.Resource.MapBindingsToPorts().MapPortsToDockerComposePorts())
+            .WithCommands(commands.ToArray())
+            .WithRestartPolicy(ERestartMode.UnlessStopped);
+
+        var service = serviceBuilder.Build();
+
+        return new ComposeService { Service = service };
+    }
+
+    public override List<object> CreateKubernetesObjects(CreateKubernetesObjectsOptions options)
+    {
+        var exec = options.Resource.Value as ExecutableResource;
+
+        var data = new KubernetesDeploymentData()
+            .SetWithDashboard(options.WithDashboard.GetValueOrDefault())
+            .SetName(options.Resource.Key)
+            .SetContainerImage("busybox:latest")
+            .SetImagePullPolicy(options.ImagePullPolicy)
+            .SetEnv(GetFilteredEnvironmentalVariables(options.Resource, options.DisableSecrets, options.WithDashboard))
+            .SetArgs(exec?.Args)
+            .SetEntrypoint(exec?.Command)
+            .SetPorts(options.Resource.MapBindingsToPorts())
+            .SetManifests([])
+            .SetWithPrivateRegistry(options.WithPrivateRegistry.GetValueOrDefault())
+            .ApplyIngress(options)
+            .Validate();
+
+        return data.ToKubernetesObjects(options.EncodeSecrets);
+    }
+}

--- a/src/Aspirate.Processors/ServiceCollectionExtensions.cs
+++ b/src/Aspirate.Processors/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtensions
             .RegisterProcessor<DaprComponentProcessor>(AspireComponentLiterals.DaprComponent)
             .RegisterProcessor<ParameterProcessor>(AspireComponentLiterals.Parameter)
             .RegisterProcessor<ValueProcessor>(AspireComponentLiterals.Value)
+            .RegisterProcessor<ExecutableProcessor>(AspireComponentLiterals.Executable)
             .RegisterProcessor<FinalProcessor>(AspireLiterals.Final);
 
     public static IServiceCollection AddPlaceholderTransformation(this IServiceCollection services) =>

--- a/src/Aspirate.Shared/Literals/AspireComponentLiterals.cs
+++ b/src/Aspirate.Shared/Literals/AspireComponentLiterals.cs
@@ -16,4 +16,5 @@ public static class AspireComponentLiterals
 
     public const string Value = "value.v0";
     public const string Parameter = "parameter.v0";
+    public const string Executable = "executable.v0";
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/ExecutableResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/ExecutableResource.cs
@@ -1,0 +1,23 @@
+namespace Aspirate.Shared.Models.AspireManifests.Components.V0;
+
+[ExcludeFromCodeCoverage]
+public class ExecutableResource : Resource,
+    IResourceWithEnvironmentalVariables,
+    IResourceWithBinding,
+    IResourceWithArgs
+{
+    [JsonPropertyName("command")]
+    public string? Command { get; set; }
+
+    [JsonPropertyName("workingDirectory")]
+    public string? WorkingDirectory { get; set; }
+
+    [JsonPropertyName("env")]
+    public Dictionary<string, string>? Env { get; set; } = [];
+
+    [JsonPropertyName("bindings")]
+    public Dictionary<string, Binding>? Bindings { get; set; } = [];
+
+    [JsonPropertyName("args")]
+    public List<string>? Args { get; set; } = [];
+}

--- a/src/Aspirate.Shared/Models/AspireManifests/Resource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Resource.cs
@@ -13,6 +13,7 @@ namespace Aspirate.Shared.Models.AspireManifests;
 [JsonDerivedType(typeof(DaprComponentResource), typeDiscriminator: "aspire.daprcomponent")]
 [JsonDerivedType(typeof(ParameterResource), typeDiscriminator: "aspire.parameter")]
 [JsonDerivedType(typeof(ValueResource), typeDiscriminator: "aspire.value")]
+[JsonDerivedType(typeof(ExecutableResource), typeDiscriminator: "aspire.executable")]
 public abstract class Resource : IResource
 {
     [JsonPropertyName("name")]


### PR DESCRIPTION
## Summary
- add `ExecutableResource` model for running commands
- implement `ExecutableProcessor` to turn the resource into Kubernetes and Compose outputs
- register the new processor

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6868c4e8ada4833180cebecd6fb32837