### PR TITLE
Implement advanced password generation support

### DIFF
--- a/src/Aspirate.Commands/Actions/Secrets/PopulateInputsAction.cs
+++ b/src/Aspirate.Commands/Actions/Secrets/PopulateInputsAction.cs
@@ -160,8 +160,17 @@ public sealed class PopulateInputsAction(
             {
                 continue;
             }
-            var minimumLength = input.Value.Default?.Generate?.MinLength ?? 22;
-            parameterResource.Value = passwordGenerator.Generate(minimumLength);
+
+            if (!string.IsNullOrEmpty(input.Value.Default?.Value))
+            {
+                parameterResource.Value = input.Value.Default!.Value;
+            }
+            else
+            {
+                var options = input.Value.Default?.Generate ?? new Generate { MinLength = 22 };
+                parameterResource.Value = passwordGenerator.Generate(options);
+            }
+
             AddParameterInputToSecretStore(input, parameterResource, parameterResource.Value);
 
             Logger.MarkupLine($"Successfully [green]generated[/] a value for [blue]{parameterResource.Name}'s[/] Input Value [blue]'{input.Key}'[/]");

--- a/src/Aspirate.Services/GlobalUsings.cs
+++ b/src/Aspirate.Services/GlobalUsings.cs
@@ -10,6 +10,7 @@ global using Ardalis.SmartEnum.SystemTextJson;
 global using Aspirate.Services.Implementations;
 global using Aspirate.Secrets;
 global using Aspirate.Shared.Enums;
+global using Aspirate.Shared.Models.AspireManifests.Components.V0.Parameters;
 global using Aspirate.Shared.Exceptions;
 global using Aspirate.Shared.Extensions;
 global using Aspirate.Shared.Inputs;

--- a/src/Aspirate.Services/Implementations/PasswordGenerator.cs
+++ b/src/Aspirate.Services/Implementations/PasswordGenerator.cs
@@ -2,18 +2,119 @@ namespace Aspirate.Services.Implementations;
 
 public class PasswordGenerator : IPasswordGenerator
 {
-    private const string Characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!";
+    private const string LowerCharacters = "abcdefghijklmnopqrstuvwxyz";
+    private const string UpperCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private const string NumericCharacters = "0123456789";
+    private const string SpecialCharacters = "!@#$%^&*()-_=+[]";
 
-    public string Generate(int length = 24)
+    public string Generate(Generate options)
     {
-        var charactersLength = Characters.Length;
-        var password = new StringBuilder(length);
-
-        for (var i = 0; i < length; i++)
+        var pool = new List<char>();
+        if (options.Lower)
         {
-            password.Append(Characters[RandomNumberGenerator.GetInt32(charactersLength)]);
+            pool.AddRange(LowerCharacters);
+        }
+        if (options.Upper)
+        {
+            pool.AddRange(UpperCharacters);
+        }
+        if (options.Numeric)
+        {
+            pool.AddRange(NumericCharacters);
+        }
+        if (options.Special)
+        {
+            pool.AddRange(SpecialCharacters);
         }
 
-        return password.ToString();
+        if (pool.Count == 0)
+        {
+            throw new InvalidOperationException("No characters available to generate password.");
+        }
+
+        var builder = new StringBuilder(options.MinLength);
+
+        AppendRandom(builder, LowerCharacters, options.MinLower);
+        AppendRandom(builder, UpperCharacters, options.MinUpper);
+        AppendRandom(builder, NumericCharacters, options.MinNumeric);
+        AppendRandom(builder, SpecialCharacters, options.MinSpecial);
+
+        for (var i = builder.Length; i < options.MinLength; i++)
+        {
+            builder.Append(pool[RandomNumberGenerator.GetInt32(pool.Count)]);
+        }
+
+        return Shuffle(builder.ToString());
+    }
+
+    public bool Validate(string value, Generate options)
+    {
+        if (value.Length < options.MinLength)
+        {
+            return false;
+        }
+
+        if (options.Lower && value.Count(char.IsLower) < options.MinLower)
+        {
+            return false;
+        }
+
+        if (!options.Lower && value.Any(char.IsLower))
+        {
+            return false;
+        }
+
+        if (options.Upper && value.Count(char.IsUpper) < options.MinUpper)
+        {
+            return false;
+        }
+
+        if (!options.Upper && value.Any(char.IsUpper))
+        {
+            return false;
+        }
+
+        if (options.Numeric && value.Count(char.IsDigit) < options.MinNumeric)
+        {
+            return false;
+        }
+
+        if (!options.Numeric && value.Any(char.IsDigit))
+        {
+            return false;
+        }
+
+        var specialCount = value.Count(c => !char.IsLetterOrDigit(c));
+        if (options.Special && specialCount < options.MinSpecial)
+        {
+            return false;
+        }
+
+        if (!options.Special && specialCount > 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void AppendRandom(StringBuilder builder, string chars, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            builder.Append(chars[RandomNumberGenerator.GetInt32(chars.Length)]);
+        }
+    }
+
+    private static string Shuffle(string value)
+    {
+        var chars = value.ToCharArray();
+        for (var i = chars.Length - 1; i > 0; i--)
+        {
+            var j = RandomNumberGenerator.GetInt32(i + 1);
+            (chars[i], chars[j]) = (chars[j], chars[i]);
+        }
+
+        return new string(chars);
     }
 }

--- a/src/Aspirate.Shared/Interfaces/Secrets/IPasswordGenerator.cs
+++ b/src/Aspirate.Shared/Interfaces/Secrets/IPasswordGenerator.cs
@@ -2,5 +2,7 @@ namespace Aspirate.Shared.Interfaces.Secrets;
 
 public interface IPasswordGenerator
 {
-    string Generate(int length = 24);
+    string Generate(Generate options);
+
+    bool Validate(string value, Generate options);
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/Generate.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/Generate.cs
@@ -5,4 +5,28 @@ public class Generate
 {
     [JsonPropertyName("minLength")]
     public int MinLength { get; set; }
+
+    [JsonPropertyName("lower")]
+    public bool Lower { get; set; } = true;
+
+    [JsonPropertyName("upper")]
+    public bool Upper { get; set; } = true;
+
+    [JsonPropertyName("numeric")]
+    public bool Numeric { get; set; } = true;
+
+    [JsonPropertyName("special")]
+    public bool Special { get; set; } = true;
+
+    [JsonPropertyName("minLower")]
+    public int MinLower { get; set; }
+
+    [JsonPropertyName("minUpper")]
+    public int MinUpper { get; set; }
+
+    [JsonPropertyName("minNumeric")]
+    public int MinNumeric { get; set; }
+
+    [JsonPropertyName("minSpecial")]
+    public int MinSpecial { get; set; }
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ParameterDefault.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ParameterDefault.cs
@@ -2,6 +2,9 @@ namespace Aspirate.Shared.Models.AspireManifests.Components.V0.Parameters;
 
 public class ParameterDefault
 {
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
+
     [JsonPropertyName("generate")]
     public Generate? Generate { get; set; }
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ParameterInput.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ParameterInput.cs
@@ -3,6 +3,9 @@
 [ExcludeFromCodeCoverage]
 public class ParameterInput
 {
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
     [JsonPropertyName("default")]
     public ParameterDefault? Default { get; set; }
 

--- a/tests/Aspirate.Tests/ActionsTests/Secrets/PopulateInputsActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Secrets/PopulateInputsActionTests.cs
@@ -53,6 +53,9 @@ public class PopulateInputsActionTests : BaseActionTests<PopulateInputsAction>
         postgresParams.Value.Should().HaveLength(22);
         postgres2Params.Value.Should().HaveLength(22);
         postgresParams.Value.Should().NotBe(postgres2Params.Value);
+        postgresParams.Value.Count(char.IsLower).Should().BeGreaterOrEqualTo(1);
+        postgresParams.Value.Count(char.IsUpper).Should().BeGreaterOrEqualTo(1);
+        postgresParams.Value.Count(char.IsDigit).Should().BeGreaterOrEqualTo(1);
     }
 
     private static void EnterPasswordInput(TestConsole console, string password)

--- a/tests/Aspirate.Tests/AspirateTestBase.cs
+++ b/tests/Aspirate.Tests/AspirateTestBase.cs
@@ -205,6 +205,9 @@ public abstract class AspirateTestBase
                         Generate = new Generate
                         {
                             MinLength = 22,
+                            MinLower = 1,
+                            MinUpper = 1,
+                            MinNumeric = 1,
                         },
                     }
                 }

--- a/tests/Aspirate.Tests/GlobalUsings.cs
+++ b/tests/Aspirate.Tests/GlobalUsings.cs
@@ -38,4 +38,5 @@ global using NSubstitute.ExceptionExtensions;
 global using Spectre.Console;
 global using Spectre.Console.Testing;
 global using ContainerResource = Aspirate.Shared.Models.AspireManifests.Components.V0.Container.ContainerResource;
+global using ContainerV1Resource = Aspirate.Shared.Models.AspireManifests.Components.V1.Container.ContainerV1Resource;
 global using Resource = Aspirate.Shared.Models.AspireManifests.Resource;

--- a/tests/Aspirate.Tests/ServiceTests/PasswordGeneratorTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/PasswordGeneratorTests.cs
@@ -1,0 +1,49 @@
+using Xunit;
+
+namespace Aspirate.Tests.ServiceTests;
+
+public class PasswordGeneratorTests : BaseServiceTests<IPasswordGenerator>
+{
+    [Fact]
+    public void Generate_RespectsMinimumCounts()
+    {
+        var state = CreateAspirateState();
+        var serviceProvider = CreateServiceProvider(state);
+        var generator = GetSystemUnderTest(serviceProvider);
+
+        var options = new Generate
+        {
+            MinLength = 10,
+            MinLower = 1,
+            MinUpper = 1,
+            MinNumeric = 1,
+            MinSpecial = 1
+        };
+
+        var password = generator.Generate(options);
+
+        password.Should().HaveLength(10);
+        password.Count(char.IsLower).Should().BeGreaterOrEqualTo(1);
+        password.Count(char.IsUpper).Should().BeGreaterOrEqualTo(1);
+        password.Count(char.IsDigit).Should().BeGreaterOrEqualTo(1);
+        password.Count(c => !char.IsLetterOrDigit(c)).Should().BeGreaterOrEqualTo(1);
+    }
+
+    [Fact]
+    public void Validate_ReturnsFalse_ForInvalidPassword()
+    {
+        var state = CreateAspirateState();
+        var serviceProvider = CreateServiceProvider(state);
+        var generator = GetSystemUnderTest(serviceProvider);
+
+        var options = new Generate
+        {
+            MinLength = 5,
+            MinUpper = 1
+        };
+
+        var result = generator.Validate("abcde", options);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- add Type for inputs and Value for parameter defaults
- expand Generate options for password rules
- implement updated PasswordGenerator and hook into PopulateInputsAction
- test password generator and input population behavior

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6868eb7cb0f483318bda537419003068