### PR TITLE
Switch value resources to connectionString property

### DIFF
--- a/src/Aspirate.Processors/Transformation/ResourceExpressionProcessor.cs
+++ b/src/Aspirate.Processors/Transformation/ResourceExpressionProcessor.cs
@@ -36,14 +36,8 @@ public sealed class ResourceExpressionProcessor(
                     resourceWithConnectionString.ConnectionString = rootNode[key]![Literals.ConnectionString]!.ToString();
                     break;
                 case ValueResource valueResource:
-                    {
-                        foreach (var resourceValue in valueResource.Values.ToList())
-                        {
-                            valueResource.Values[resourceValue.Key] = rootNode[key]![resourceValue.Key]!.ToString();
-                        }
-
-                        break;
-                    }
+                    valueResource.ConnectionString = rootNode[key]![Literals.ConnectionString]!.ToString();
+                    break;
             }
 
             if (value is IResourceWithEnvironmentalVariables resourceWithEnvVars && resourceWithEnvVars.Env is not null)

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ValueResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ValueResource.cs
@@ -2,6 +2,6 @@ namespace Aspirate.Shared.Models.AspireManifests.Components.V0.Parameters;
 
 public class ValueResource : Resource
 {
-    [JsonExtensionData]
-    public Dictionary<string, object> Values { get; init; } = [];
+    [JsonPropertyName("connectionString")]
+    public required string ConnectionString { get; set; }
 }


### PR DESCRIPTION
## Summary
- add `ConnectionString` property to `ValueResource`
- modify `ResourceExpressionProcessor` to substitute `ValueResource.ConnectionString`

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6868f0acea288331b0c82b42293cd1c4