### PR TITLE
Support read-only volume mounts

### DIFF
--- a/src/Aspirate.Cli/Templates/deployment.hbs
+++ b/src/Aspirate.Cli/Templates/deployment.hbs
@@ -64,4 +64,14 @@ spec:
         - secretRef:
             name: {{name}}-secrets
         {{/if}}
+        {{#if hasVolumes}}
+        volumeMounts:
+        {{#each volumes}}
+        - name: {{this.name}}
+          mountPath: {{this.target}}
+          {{#if this.readOnly}}
+          readOnly: true
+          {{/if}}
+        {{/each}}
+        {{/if}}
       terminationGracePeriodSeconds: 180

--- a/src/Aspirate.Cli/Templates/statefulset.hbs
+++ b/src/Aspirate.Cli/Templates/statefulset.hbs
@@ -66,6 +66,9 @@ spec:
           {{#each volumes}}
             - name: {{this.name}}
               mountPath: {{this.target}}
+            {{#if this.readOnly}}
+            readOnly: true
+            {{/if}}
           {{/each}}
       {{/if}}
   {{#if hasVolumes}}

--- a/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
@@ -92,10 +92,20 @@ public static class KubernetesDeploymentDataExtensions
 
         if (data.HasVolumes)
         {
-            volumeMounts.AddRange(data.Volumes.Select(x => new V1VolumeMount
+            volumeMounts.AddRange(data.Volumes.Select(x =>
             {
-                Name = x.Name,
-                MountPath = x.Target,
+                var mount = new V1VolumeMount
+                {
+                    Name = x.Name,
+                    MountPath = x.Target,
+                };
+
+                if (x.ReadOnly)
+                {
+                    mount.ReadOnlyProperty = true;
+                }
+
+                return mount;
             }));
         }
 


### PR DESCRIPTION
## Summary
- enable readonly mount support in KubernetesDeploymentDataExtensions
- handle readonly flag in Helm templates
- test readonly volumes and verify YAML output

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6868f5d35c1883318f7f136d010f814f