### PR TITLE
Allow custom resource types

### DIFF
--- a/src/Aspirate.Processors/Transformation/ResourceExpressionProcessor.cs
+++ b/src/Aspirate.Processors/Transformation/ResourceExpressionProcessor.cs
@@ -1,3 +1,4 @@
+using Aspirate.Shared.Models.AspireManifests.Components;
 namespace Aspirate.Processors.Transformation;
 
 public sealed class ResourceExpressionProcessor(
@@ -14,7 +15,8 @@ public sealed class ResourceExpressionProcessor(
     {
         resources.EnsureBindingsHavePorts();
 
-        var jsonDocument = resources.Where(r => r.Value is not UnsupportedResource)
+        var jsonDocument = resources
+            .Where(r => r.Value is not UnsupportedResource && r.Value is not ExtensionResource)
             .ToDictionary(p => p.Key, p => p.Value)
             .TryParseAsJsonNode();
 

--- a/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
+++ b/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
@@ -1,3 +1,6 @@
+using Aspirate.Shared.Models.AspireManifests.Components;
+using System.Text.Json.Nodes;
+
 namespace Aspirate.Services.Implementations;
 
 /// <inheritdoc />
@@ -58,8 +61,9 @@ public class ManifestFileParserService(
             }
             else
             {
-                console.MarkupLine($"[yellow]Resource '{resourceName}' is unsupported type '{type}'. Skipping as UnsupportedResource.[/]");
-                resource = new UnsupportedResource();
+                console.MarkupLine($"[yellow]Resource '{resourceName}' is unsupported type '{type}'. Preserving as ExtensionResource.[/]");
+                var jsonNode = JsonNode.Parse(resourceElement.GetRawText());
+                resource = new ExtensionResource(jsonNode!, type);
             }
 
             if (resource != null)

--- a/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
@@ -1,3 +1,4 @@
+using Aspirate.Shared.Models.AspireManifests.Components;
 namespace Aspirate.Shared.Models.Aspirate;
 
 public class AspirateState :
@@ -199,7 +200,7 @@ public class AspirateState :
     [JsonIgnore]
     public List<KeyValuePair<string, Resource>> AllSelectedSupportedComponents =>
         LoadedAspireManifestResources
-            .Where(x => x.Value is not UnsupportedResource && AspireComponentsToProcess.Contains(x.Key))
+            .Where(x => x.Value is not UnsupportedResource && x.Value is not ExtensionResource && AspireComponentsToProcess.Contains(x.Key))
             .ToList();
 
     [JsonIgnore]

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/ExtensionResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/ExtensionResource.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
+namespace Aspirate.Shared.Models.AspireManifests.Components;
+
+/// <summary>
+/// Represents a custom resource type not natively supported.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ExtensionResource : Resource
+{
+    public ExtensionResource(JsonNode rawJson, string type)
+    {
+        Type = type;
+        RawJson = rawJson;
+    }
+
+    [JsonIgnore]
+    public JsonNode RawJson { get; }
+}

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -80,7 +80,7 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
-    public void LoadAndParseAspireManifest_ReturnsUnsupportedResource_WhenResourceTypeIsUnsupported()
+    public void LoadAndParseAspireManifest_ReturnsExtensionResource_WhenResourceTypeIsUnsupported()
     {
         // Arrange
         var fileSystem = new MockFileSystem();
@@ -94,7 +94,27 @@ public class ManifestFileParserServiceTest
 
         // Assert
         result.Should().HaveCount(1);
-        result["resource1"].Should().BeOfType<UnsupportedResource>();
+        result["resource1"].Should().BeOfType<ExtensionResource>();
+    }
+
+    [Fact]
+    public void LoadAndParseAspireManifest_PreservesUnknownResourceTypeJson()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "unknown.json";
+        fileSystem.AddFile(manifestFile, new("{\"resources\": {\"res\": {\"type\": \"custom.v0\", \"foo\": \"bar\"}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        var result = service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        result.Should().HaveCount(1);
+        var ext = result["res"].As<ExtensionResource>();
+        ext.Type.Should().Be("custom.v0");
+        ext.RawJson!["foo"]!.ToString().Should().Be("bar");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- keep unknown resources instead of discarding them
- add `ExtensionResource` to store unknown JSON
- ignore `ExtensionResource` when processing standard resources
- support extension resources in parser service
- test preservation of unknown resource types

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6868f9852b148331b1371e038c2b1f23