### PR TITLE
Fix Binding scheme serialization

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Binding.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Binding.cs
@@ -7,9 +7,9 @@ namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 public class Binding
 {
     /// <summary>
-    /// The schema of the binding.
+    /// The scheme of the binding.
     /// </summary>
-    [JsonPropertyName("schema")]
+    [JsonPropertyName("scheme")]
     public string? Scheme { get; set; } = "http";
 
     /// <summary>

--- a/tests/Aspirate.Tests/ModelTests/BindingSerializationTests.cs
+++ b/tests/Aspirate.Tests/ModelTests/BindingSerializationTests.cs
@@ -1,0 +1,15 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Aspirate.Tests.ModelTests;
+
+public class BindingSerializationTests
+{
+    [Fact]
+    public void Binding_Serializes_UsingSchemeProperty()
+    {
+        var binding = new Binding { Scheme = "https" };
+        var json = JsonSerializer.Serialize(binding);
+        json.Should().Contain("\"scheme\":\"https\"");
+    }
+}


### PR DESCRIPTION
## Summary
- correct JSON property name for Binding scheme
- add regression test for serialization

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6869174941408331bfffa96f0db8ac8f