### PR TITLE
Support Bicep deployment scope

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Azure/BicepScope.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Azure/BicepScope.cs
@@ -1,0 +1,11 @@
+namespace Aspirate.Shared.Models.AspireManifests.Components.Azure;
+
+/// <summary>
+/// Represents the scope for a bicep deployment.
+/// </summary>
+public class BicepScope
+{
+    [JsonPropertyName("resourceGroup")]
+    public string? ResourceGroup { get; set; }
+}
+

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Azure/BicepV1Resource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Azure/BicepV1Resource.cs
@@ -6,5 +6,5 @@ namespace Aspirate.Shared.Models.AspireManifests.Components.Azure;
 public class BicepV1Resource : BicepResource
 {
     [JsonPropertyName("scope")]
-    public string? Scope { get; set; }
+    public BicepScope? Scope { get; set; }
 }

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -243,6 +243,7 @@ public class ManifestFileParserServiceTest
         var proj = results["app"] as ProjectV1Resource;
         proj!.Deployment.Should().NotBeNull();
         proj.Deployment!.Path.Should().Be("./redis.bicep");
+        proj.Deployment!.Scope!.ResourceGroup.Should().Be("rg-name");
         proj.Env.Should().ContainKey("ASPNETCORE_ENVIRONMENT");
     }
 
@@ -266,6 +267,7 @@ public class ManifestFileParserServiceTest
         var container = results["cache"] as ContainerV1Resource;
         container!.Deployment.Should().NotBeNull();
         container.Deployment!.Path.Should().Be("./redis.bicep");
+        container.Deployment!.Scope!.ResourceGroup.Should().Be("rg-name");
     }
 
     [Fact]

--- a/tests/Aspirate.Tests/TestData/container-v1-deployment.json
+++ b/tests/Aspirate.Tests/TestData/container-v1-deployment.json
@@ -6,7 +6,9 @@
       "deployment": {
         "type": "azure.bicep.v1",
         "path": "./redis.bicep",
-        "scope": "resourceGroup"
+        "scope": {
+          "resourceGroup": "rg-name"
+        }
       }
     }
   }

--- a/tests/Aspirate.Tests/TestData/project-v1-deployment.json
+++ b/tests/Aspirate.Tests/TestData/project-v1-deployment.json
@@ -17,7 +17,9 @@
       "deployment": {
         "type": "azure.bicep.v1",
         "path": "./redis.bicep",
-        "scope": "resourceGroup"
+        "scope": {
+          "resourceGroup": "rg-name"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add `BicepScope` model for manifest v1 deployments
- use `BicepScope` in `BicepV1Resource`
- update manifest examples and parsing tests for new scope syntax

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj` *(fails: NETSDK1045: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_686918f88c008331b3bf2e3353148dba