### PR TITLE
Support Json values in Bicep params

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Azure/BicepResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Azure/BicepResource.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Aspirate.Shared.Models.AspireManifests.Components.Azure;
 
 /// <summary>
@@ -12,5 +14,5 @@ public class BicepResource : Resource, IResourceWithConnectionString
     public string? ConnectionString { get; set; }
 
     [JsonPropertyName("params")]
-    public Dictionary<string, string>? Params { get; set; }
+    public Dictionary<string, JsonElement>? Params { get; set; }
 }

--- a/tests/Aspirate.Tests/ModelTests/BicepResourceSerializationTests.cs
+++ b/tests/Aspirate.Tests/ModelTests/BicepResourceSerializationTests.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using Aspirate.Shared.Models.AspireManifests.Components.Azure;
+using FluentAssertions;
+using Xunit;
+
+namespace Aspirate.Tests.ModelTests;
+
+public class BicepResourceSerializationTests
+{
+    [Fact]
+    public void BicepResource_Params_RoundTrips_MultiTypes()
+    {
+        // Arrange
+        var json = """
+        {
+            "number": 1,
+            "array": [1, 2, 3],
+            "object": { "a": true }
+        }
+        """;
+        using var doc = JsonDocument.Parse(json);
+        var dict = doc.RootElement.EnumerateObject()
+            .ToDictionary(p => p.Name, p => p.Value.Clone());
+
+        var resource = new BicepResource
+        {
+            Params = dict
+        };
+
+        // Act
+        var serialized = JsonSerializer.Serialize(resource);
+        var deserialized = JsonSerializer.Deserialize<BicepResource>(serialized)!;
+
+        // Assert
+        deserialized.Params.Should().ContainKey("number");
+        deserialized.Params!["number"].ValueKind.Should().Be(JsonValueKind.Number);
+        deserialized.Params["number"].GetInt32().Should().Be(1);
+
+        deserialized.Params.Should().ContainKey("array");
+        deserialized.Params["array"].ValueKind.Should().Be(JsonValueKind.Array);
+        deserialized.Params["array"].EnumerateArray().Select(e => e.GetInt32()).Should().Equal(1, 2, 3);
+
+        deserialized.Params.Should().ContainKey("object");
+        deserialized.Params["object"].ValueKind.Should().Be(JsonValueKind.Object);
+        deserialized.Params["object"].GetProperty("a").GetBoolean().Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- allow `BicepResource.Params` to store arbitrary JSON types
- test round tripping of numbers, arrays and objects

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68691caa9cf8833182bcfa8384208301