### PR TITLE
Update CloudFormation references

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Aws/CloudFormationReference.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Aws/CloudFormationReference.cs
@@ -1,0 +1,10 @@
+namespace Aspirate.Shared.Models.AspireManifests.Components.Aws;
+
+/// <summary>
+/// Represents a reference to another resource for CloudFormation operations.
+/// </summary>
+public class CloudFormationReference
+{
+    [JsonPropertyName("target-resource")]
+    public string? TargetResource { get; set; }
+}

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Aws/CloudFormationStackResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Aws/CloudFormationStackResource.cs
@@ -8,11 +8,8 @@ public class CloudFormationStackResource : Resource
     [JsonPropertyName("stack-name")]
     public string? StackName { get; set; }
 
-    [JsonPropertyName("template-path")]
-    public string? TemplatePath { get; set; }
-
     [JsonPropertyName("references")]
-    public Dictionary<string, string>? References { get; set; }
+    public List<CloudFormationReference>? References { get; set; }
 
     [JsonExtensionData]
     public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Aws/CloudFormationTemplateResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Aws/CloudFormationTemplateResource.cs
@@ -12,7 +12,7 @@ public class CloudFormationTemplateResource : Resource
     public string? TemplatePath { get; set; }
 
     [JsonPropertyName("references")]
-    public Dictionary<string, string>? References { get; set; }
+    public List<CloudFormationReference>? References { get; set; }
 
     [JsonExtensionData]
     public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }


### PR DESCRIPTION
## Summary
- add `CloudFormationReference` model
- store stack references as a list and drop `TemplatePath`
- use `CloudFormationReference` in template resources

## Testing
- `dotnet test Aspirate.sln`

------
https://chatgpt.com/codex/tasks/task_e_68691e7a48b08331bc01c2a06963d594