### PR TITLE
Add Dapr resource validation

### DIFF
--- a/docs/Writerside/hi.tree
+++ b/docs/Writerside/hi.tree
@@ -32,6 +32,7 @@
     <toc-element topic="Configurable-State-Path.md"/>
     <toc-element topic="File-Permissions.md"/>
     <toc-element topic="External-Providers.md"/>
+    <toc-element topic="Dapr-Support.md"/>
     <toc-element topic="Security-Best-Practices.md"/>
     <toc-element topic="Troubleshooting.md"/>
 </instance-profile>

--- a/docs/Writerside/topics/Dapr-Support.md
+++ b/docs/Writerside/topics/Dapr-Support.md
@@ -1,0 +1,11 @@
+# Dapr Support
+
+%product% can include `dapr.v0` resources to run Dapr sidecars alongside your components.
+When defining a Dapr resource the following fields are required:
+
+- `metadata` – configuration object for the sidecar.
+- `metadata.application` – name of the application component the sidecar attaches to.
+- `metadata.appId` – Dapr application identifier.
+- `metadata.components` – list of components that should be loaded.
+
+If any of these values are omitted, an `InvalidOperationException` is thrown when generating Docker Compose entries.

--- a/src/Aspirate.Processors/Resources/Dapr/DaprProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Dapr/DaprProcessor.cs
@@ -17,11 +17,40 @@ public class DaprProcessor(
 
     public override List<object> CreateKubernetesObjects(CreateKubernetesObjectsOptions options) => [];
 
+    private static void ValidateDaprResource(DaprResource? resource, string name)
+    {
+        if (resource == null)
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.DaprSystem} {name} not found.");
+        }
+
+        if (resource.Metadata is null)
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.DaprSystem} {name} missing required property 'metadata'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(resource.Metadata.Application))
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.DaprSystem} {name} missing required property 'application'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(resource.Metadata.AppId))
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.DaprSystem} {name} missing required property 'appId'.");
+        }
+
+        if (resource.Metadata.Components is null || resource.Metadata.Components.Count == 0)
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.DaprSystem} {name} missing required property 'components'.");
+        }
+    }
+
     public override ComposeService CreateComposeEntry(CreateComposeEntryOptions options)
     {
         var response = new ComposeService();
 
         var daprResource = options.Resource.Value as DaprResource;
+        ValidateDaprResource(daprResource, options.Resource.Key);
 
         var commands = new List<string>
         {

--- a/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
+++ b/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
@@ -104,4 +104,76 @@ public class RequiredPropertyValidationTests
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*missing required property 'command'");
     }
+
+    [Fact]
+    public void DaprProcessor_MissingMetadata_Throws()
+    {
+        var processor = new DaprProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());
+
+        var resource = new DaprResource();
+
+        var options = new CreateComposeEntryOptions
+        {
+            Resource = new("dapr", resource),
+        };
+
+        var act = () => processor.CreateComposeEntry(options);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'metadata'");
+    }
+
+    [Fact]
+    public void DaprProcessor_MissingApplication_Throws()
+    {
+        var processor = new DaprProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());
+
+        var resource = new DaprResource { Metadata = new() { AppId = "id", Components = ["comp"] } };
+
+        var options = new CreateComposeEntryOptions
+        {
+            Resource = new("dapr", resource),
+        };
+
+        var act = () => processor.CreateComposeEntry(options);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'application'");
+    }
+
+    [Fact]
+    public void DaprProcessor_MissingAppId_Throws()
+    {
+        var processor = new DaprProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());
+
+        var resource = new DaprResource { Metadata = new() { Application = "app", Components = ["comp"] } };
+
+        var options = new CreateComposeEntryOptions
+        {
+            Resource = new("dapr", resource),
+        };
+
+        var act = () => processor.CreateComposeEntry(options);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'appId'");
+    }
+
+    [Fact]
+    public void DaprProcessor_MissingComponents_Throws()
+    {
+        var processor = new DaprProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());
+
+        var resource = new DaprResource { Metadata = new() { Application = "app", AppId = "id" } };
+
+        var options = new CreateComposeEntryOptions
+        {
+            Resource = new("dapr", resource),
+        };
+
+        var act = () => processor.CreateComposeEntry(options);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'components'");
+    }
 }


### PR DESCRIPTION
## Summary
- validate required fields in `DaprProcessor`
- cover invalid Dapr resources with tests
- document required fields for Dapr resources

## Testing
- `dotnet test` *(fails: NETSDK1045 - requires .NET 9)*

------
https://chatgpt.com/codex/tasks/task_e_68692c2574948331b44ad3ce40368655