### PR TITLE
Validate build secrets

### DIFF
--- a/docs/Writerside/topics/Build-Command.md
+++ b/docs/Writerside/topics/Build-Command.md
@@ -39,3 +39,12 @@ When ran non-interactively, you can specify which components to build with `-c` 
 | --container-build-context     | -cbc  | `ASPIRATE_CONTAINER_BUILD_CONTEXT`     | The Container Build Context to use when Dockerfile is used to build projects.                                                                                                                |
 | --container-build-arg         | -cba  | `ASPIRATE_CONTAINER_BUILD_ARGS`        | The Container Build Arguments to use for all projects with custom Dockerfile. In `key=value` format. Can include multiple times.                                                             |
 | --components                  | -c    | `ASPIRATE_COMPONENTS`                  | The components/resources to process. Example: -c webApi -c frontend -c sql -c redis . Components must be written exactly as they appear in manifest.json. Only works when ran non-interactive|
+
+## Build Secrets
+
+The `build` section in a manifest supports defining `secrets` to supply sensitive data during container builds. Each secret requires a `type` and either a `value` or `source` property depending on the chosen type:
+
+- `env` \- provide the secret via an environment variable by setting `value`.
+- `file` \- reference a file on disk using the `source` path.
+
+`env` secrets are exported to the environment before the container builder is invoked.


### PR DESCRIPTION
## Summary
- validate build secrets before passing to docker
- test invalid build secret definitions
- document secret properties for the build command

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68692e1b69608331abf4edbdd1b098cd