### PR TITLE
Validate CloudFormation manifest fields

### DIFF
--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -139,6 +139,42 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenCloudFormationStackMissingStackName()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "missing-stack-name.json";
+        fileSystem.AddFile(manifestFile, new("{\"resources\": {\"stack\": {\"type\": \"aws.cloudformation.stack.v0\", \"template-path\": \"./stack.yml\"}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'stack-name'");
+    }
+
+    [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenCloudFormationTemplateMissingTemplatePath()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "missing-template-path.json";
+        fileSystem.AddFile(manifestFile, new("{\"resources\": {\"tmpl\": {\"type\": \"aws.cloudformation.template.v0\", \"stack-name\": \"demo\"}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'template-path'");
+    }
+
+    [Fact]
     public void LoadAndParseAspireManifest_ReturnsResource_WhenResourceTypeIsSupported()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add validation for required properties in CloudFormation processors
- throw when `stack-name` or `template-path` are missing
- cover validation in manifest parser tests

## Testing
- `dotnet build tests/Aspirate.Tests/Aspirate.Tests.csproj -v minimal` *(fails: NETSDK1045 / CS1503)*

------
https://chatgpt.com/codex/tasks/task_e_686932c61b7c833191cd724e34c4646d