### PR TITLE
Document manifest extensions and test annotations

### DIFF
--- a/docs/Writerside/topics/Generate-Command.md
+++ b/docs/Writerside/topics/Generate-Command.md
@@ -57,6 +57,10 @@ can deploy them alongside other components.
 
 AWS CloudFormation templates can be referenced in your manifest using `aws.cloudformation.stack.v0` or `aws.cloudformation.template.v0` resources. These entries are also preserved during generation so you can deploy them alongside other components. Unknown properties on these resources are retained when parsing the manifest.
 
+## Manifest extensions
+
+`aspirate` accepts additional fields beyond the official .NET Aspire schema. For example, container and project resources can include an `annotations` object which is used to apply Kubernetes annotations to generated manifests. These extra fields are treated as extensions and are preserved when reading and writing manifest files.
+
 ##Specify components when running with `--non-interactive`
 When ran non-interactively, you can specify which components to build with `-c` or `--components`. Example: `-c webApi -c frontend -c sql -c redis`.
 

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -139,6 +139,25 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
+    public void LoadAndParseAspireManifest_PreservesAnnotations()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "annotations.json";
+        fileSystem.AddFile(manifestFile, new("{\"resources\": {\"svc\": {\"type\": \"container.v0\", \"image\": \"img\", \"annotations\": {\"key\": \"val\"}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        var result = service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        result.Should().HaveCount(1);
+        var container = result["svc"].As<ContainerResource>();
+        container.Annotations.Should().ContainKey("key").WhoseValue.Should().Be("val");
+    }
+
+    [Fact]
     public void LoadAndParseAspireManifest_Throws_WhenCloudFormationStackMissingStackName()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- note additional manifest extension fields
- ensure annotations property is parsed

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693bc294048331a5890ea2ecb54757