### PR TITLE
Support unnamed bind mounts

### DIFF
--- a/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
@@ -68,11 +68,6 @@ public abstract class BaseContainerProcessor<TContainerResource>(
 
         foreach (var mount in container.BindMounts)
         {
-            if (string.IsNullOrWhiteSpace(mount.Name))
-            {
-                throw new InvalidOperationException($"{AspireComponentLiterals.Container} {name} bindMount missing required property 'name'.");
-            }
-
             if (string.IsNullOrWhiteSpace(mount.Source))
             {
                 throw new InvalidOperationException($"{AspireComponentLiterals.Container} {name} bindMount missing required property 'source'.");

--- a/src/Aspirate.Shared/Extensions/ResourceExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/ResourceExtensions.cs
@@ -75,6 +75,8 @@ public static class ResourceExtensions
             return bindMounts;
         }
 
+        var usedNames = new HashSet<string>();
+
         foreach (var mount in bindMounts)
         {
             if (string.IsNullOrWhiteSpace(mount.Source))
@@ -89,10 +91,24 @@ public static class ResourceExtensions
 
             if (string.IsNullOrWhiteSpace(mount.Name))
             {
-                throw new InvalidOperationException($"BindMount missing required property 'name'.");
+                var generated = mount.Source
+                    .Replace("/", "-")
+                    .Replace(".", "-")
+                    .Trim('-')
+                    .ToLowerInvariant();
+
+                var baseName = generated;
+                var index = 1;
+                while (!usedNames.Add(generated))
+                {
+                    generated = $"{baseName}-{index++}";
+                }
+
+                mount.Name = generated;
             }
 
             mount.Name = mount.Name.Replace("/", "-").Replace(".", "-").Replace("--", "-").ToLowerInvariant();
+            usedNames.Add(mount.Name);
         }
 
         return bindMounts;

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BindMount.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BindMount.cs
@@ -4,6 +4,7 @@ namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 public class BindMount
 {
     [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Name { get; set; }
 
     [JsonPropertyName("source")]

--- a/tests/Aspirate.Tests/ExtensionTests/KubernetesDeploymentDataExtensionTests.cs
+++ b/tests/Aspirate.Tests/ExtensionTests/KubernetesDeploymentDataExtensionTests.cs
@@ -194,6 +194,23 @@ public class KubernetesDeploymentDataExtensionTests
     }
 
     [Fact]
+    public void ToKubernetesDeployment_BindMountWithoutName_ShouldGenerateName()
+    {
+        // Arrange
+        var data = new KubernetesDeploymentData()
+            .SetName("test")
+            .SetContainerImage("test-image")
+            .SetBindMounts(new List<BindMount> { new BindMount { Source = "/logs", Target = "/data" } });
+
+        // Act
+        var result = data.ToKubernetesDeployment();
+
+        // Assert
+        result.Spec.Template.Spec.Volumes.Should().ContainSingle(v => v.Name == "logs" && v.HostPath.Path == "/logs");
+        result.Spec.Template.Spec.Containers[0].VolumeMounts.Should().ContainSingle(v => v.Name == "logs" && v.MountPath == "/data");
+    }
+
+    [Fact]
     public void ToKubernetesStatefulSet_WithReadOnlyVolume_ShouldContainReadOnlyFlag()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- allow bind mounts without a name when validating containers
- auto-generate bind mount names from the source path
- omit the name when serializing if it was not specified
- test bind mounts that lack a name

## Testing
- `/usr/share/dotnet9/dotnet test -c Release` *(fails: DockerfileProcessor, ContainerProcessor, etc. not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694015035483319b58ae01208fadb0