### PR TITLE
Add ParameterResource validation on deserialization

### DIFF
--- a/src/Aspirate.Processors/Resources/AbstractProcessors/ParameterProcessor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/ParameterProcessor.cs
@@ -8,8 +8,35 @@ public class ParameterProcessor(IFileSystem fileSystem, IAnsiConsole console,
     public override string ResourceType => AspireComponentLiterals.Parameter;
 
     /// <inheritdoc />
-    public override Resource? Deserialize(ref Utf8JsonReader reader) =>
-        JsonSerializer.Deserialize<ParameterResource>(ref reader);
+    public override Resource? Deserialize(ref Utf8JsonReader reader)
+    {
+        var parameter = JsonSerializer.Deserialize<ParameterResource>(ref reader);
+
+        ValidateParameterResource(parameter);
+
+        return parameter;
+    }
+
+    private static void ValidateParameterResource(ParameterResource? parameter)
+    {
+        if (parameter == null)
+        {
+            throw new InvalidOperationException(
+                $"{AspireComponentLiterals.Parameter} not found.");
+        }
+
+        if (parameter.Value is null)
+        {
+            throw new InvalidOperationException(
+                $"{AspireComponentLiterals.Parameter} {parameter.Name} missing required property 'value'.");
+        }
+
+        if (parameter.Inputs is null)
+        {
+            throw new InvalidOperationException(
+                $"{AspireComponentLiterals.Parameter} {parameter.Name} missing required property 'inputs'.");
+        }
+    }
 
     public override Task<bool> CreateManifests(CreateManifestsOptions options) =>
         // Do nothing for Parameter Resources, they are there for configuration.

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -194,6 +194,44 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenParameterMissingValue()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "missing-parameter-value.json";
+        fileSystem.AddFile(manifestFile,
+            new("{\"resources\": {\"param\": {\"type\": \"parameter.v0\", \"inputs\": {\"value\": {}}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'value'");
+    }
+
+    [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenParameterMissingInputs()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "missing-parameter-inputs.json";
+        fileSystem.AddFile(manifestFile,
+            new("{\"resources\": {\"param\": {\"type\": \"parameter.v0\", \"value\": \"foo\"}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'inputs'");
+    }
+
+    [Fact]
     public void LoadAndParseAspireManifest_ReturnsResource_WhenResourceTypeIsSupported()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- validate `ParameterResource` values during deserialization
- raise errors when parameter `value` or `inputs` are missing
- test malformed parameter resources throw clear errors

## Testing
- `dotnet test` *(fails: CS0246 in RequiredPropertyValidationTests)*

------
https://chatgpt.com/codex/tasks/task_e_686942d180b48331a900d2887db803e7