### PR TITLE
Support extension data on Dapr components

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Dapr/InnerDaprComponent.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Dapr/InnerDaprComponent.cs
@@ -5,9 +5,67 @@ public sealed class InnerDaprComponent
     [JsonPropertyName("type")]
     public string? Type { get; set; }
 
-    [JsonPropertyName("version")]
-    public string? Version { get; set; }
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }
 
-    [JsonPropertyName("metadata")]
-    public Dictionary<string, string>? Metadata { get; set; }
+    [JsonIgnore]
+    public string? Version
+    {
+        get
+        {
+            if (AdditionalProperties is null)
+            {
+                return null;
+            }
+
+            return AdditionalProperties.TryGetValue("version", out var element) &&
+                   element.ValueKind == JsonValueKind.String
+                ? element.GetString()
+                : null;
+        }
+        set
+        {
+            if (value is null)
+            {
+                AdditionalProperties?.Remove("version");
+                return;
+            }
+
+            AdditionalProperties ??= new();
+            AdditionalProperties["version"] = JsonDocument.Parse(JsonSerializer.Serialize(value)).RootElement.Clone();
+        }
+    }
+
+    [JsonIgnore]
+    public Dictionary<string, string>? Metadata
+    {
+        get
+        {
+            if (AdditionalProperties is null ||
+                !AdditionalProperties.TryGetValue("metadata", out var element) ||
+                element.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            var dict = new Dictionary<string, string>();
+            foreach (var prop in element.EnumerateObject())
+            {
+                dict[prop.Name] = prop.Value.ToString();
+            }
+
+            return dict;
+        }
+        set
+        {
+            if (value is null)
+            {
+                AdditionalProperties?.Remove("metadata");
+                return;
+            }
+
+            AdditionalProperties ??= new();
+            AdditionalProperties["metadata"] = JsonDocument.Parse(JsonSerializer.Serialize(value)).RootElement.Clone();
+        }
+    }
 }

--- a/tests/Aspirate.Tests/GlobalUsings.cs
+++ b/tests/Aspirate.Tests/GlobalUsings.cs
@@ -21,6 +21,7 @@ global using Aspirate.Shared.Models.AspireManifests.Components;
 global using Aspirate.Shared.Models.AspireManifests.Components.Common;
 global using Aspirate.Shared.Models.AspireManifests.Components.V0;
 global using Aspirate.Shared.Models.AspireManifests.Components.V0.Parameters;
+global using Aspirate.Shared.Models.AspireManifests.Components.V0.Dapr;
 global using Aspirate.Shared.Models.AspireManifests.Components.Aws;
 global using Aspirate.Shared.Models.AspireManifests.Interfaces;
 global using Aspirate.Shared.Models.MsBuild;

--- a/tests/Aspirate.Tests/ModelTests/DaprComponentSerializationTests.cs
+++ b/tests/Aspirate.Tests/ModelTests/DaprComponentSerializationTests.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Aspirate.Tests.ModelTests;
+
+public class DaprComponentSerializationTests
+{
+    [Fact]
+    public void DaprComponentResource_RoundTrips_WithExtensionData()
+    {
+        var json = """
+        {
+            "type": "dapr.component.v0",
+            "daprComponent": {
+                "type": "state.redis",
+                "version": "v1",
+                "metadata": { "connectionString": "redis://localhost" }
+            }
+        }
+        """;
+
+        var resource = JsonSerializer.Deserialize<DaprComponentResource>(json)!;
+
+        resource.DaprComponentProperty!.Type.Should().Be("state.redis");
+        resource.DaprComponentProperty.Version.Should().Be("v1");
+        resource.DaprComponentProperty.Metadata.Should().ContainKey("connectionString");
+
+        var serialized = JsonSerializer.Serialize(resource);
+
+        serialized.Should().Contain("\"version\":\"v1\"");
+        serialized.Should().Contain("\"metadata\"");
+
+        var roundTrip = JsonSerializer.Deserialize<DaprComponentResource>(serialized)!;
+        roundTrip.DaprComponentProperty!.Version.Should().Be("v1");
+        roundTrip.DaprComponentProperty.Metadata.Should().ContainKey("connectionString");
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle extra dapr component properties via JsonExtensionData
- expose Version and Metadata from additional data
- test Dapr component round-trips through JSON

## Testing
- `dotnet build`
- `dotnet test` *(fails: DockerfileProcessor and others not found)*

------
https://chatgpt.com/codex/tasks/task_e_686946004dcc8331af9dbd5580407d2c