### PR TITLE
Add Binding validation

### DIFF
--- a/src/Aspirate.Shared/Literals/BindingLiterals.cs
+++ b/src/Aspirate.Shared/Literals/BindingLiterals.cs
@@ -1,0 +1,13 @@
+namespace Aspirate.Shared.Literals;
+
+[ExcludeFromCodeCoverage]
+public static class BindingLiterals
+{
+    public const string Http = "http";
+    public const string Https = "https";
+    public const string Tcp = "tcp";
+    public const string Udp = "udp";
+    public const string Http2 = "http2";
+
+    public static readonly string[] ValidValues = [Http, Https, Tcp, Udp, Http2];
+}

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Binding.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Binding.cs
@@ -3,26 +3,43 @@ namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 /// <summary>
 /// A binding for a project.
 /// </summary>
+
 [ExcludeFromCodeCoverage]
 public class Binding
 {
+    private string? _scheme = BindingLiterals.Http;
+    private string? _protocol = BindingLiterals.Tcp;
+    private string? _transport;
+
     /// <summary>
     /// The scheme of the binding.
     /// </summary>
     [JsonPropertyName("scheme")]
-    public string? Scheme { get; set; } = "http";
+    public string? Scheme
+    {
+        get => _scheme;
+        set => _scheme = Validate(value, nameof(Scheme));
+    }
 
     /// <summary>
     /// The protocol of the binding.
     /// </summary>
     [JsonPropertyName("protocol")]
-    public string? Protocol { get; set; } = "tcp";
+    public string? Protocol
+    {
+        get => _protocol;
+        set => _protocol = Validate(value, nameof(Protocol));
+    }
 
     /// <summary>
     /// The transport for the binding.
     /// </summary>
     [JsonPropertyName("transport")]
-    public string? Transport { get; set; }
+    public string? Transport
+    {
+        get => _transport;
+        set => _transport = Validate(value, nameof(Transport));
+    }
 
     /// <summary>
     /// The Container Port for the binding.
@@ -41,4 +58,20 @@ public class Binding
     /// </summary>
     [JsonPropertyName("external")]
     public bool External { get; set; }
+
+    private static string? Validate(string? value, string propertyName)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (!BindingLiterals.ValidValues.Contains(value, StringComparer.OrdinalIgnoreCase))
+        {
+            var allowed = string.Join("', '", BindingLiterals.ValidValues);
+            throw new InvalidOperationException($"Binding {propertyName} must be one of: '{allowed}'.");
+        }
+
+        return value;
+    }
 }

--- a/tests/Aspirate.Tests/ModelTests/BindingSerializationTests.cs
+++ b/tests/Aspirate.Tests/ModelTests/BindingSerializationTests.cs
@@ -12,4 +12,37 @@ public class BindingSerializationTests
         var json = JsonSerializer.Serialize(binding);
         json.Should().Contain("\"scheme\":\"https\"");
     }
+
+    [Theory]
+    [InlineData("bad")]
+    [InlineData("ftp")]
+    public void Setting_Invalid_Scheme_Throws(string value)
+    {
+        var binding = new Binding();
+        var act = () => binding.Scheme = value;
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Theory]
+    [InlineData("bad")]
+    [InlineData("icmp")]
+    public void Setting_Invalid_Protocol_Throws(string value)
+    {
+        var binding = new Binding();
+        var act = () => binding.Protocol = value;
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Theory]
+    [InlineData("bad")]
+    [InlineData("spdy")]
+    public void Setting_Invalid_Transport_Throws(string value)
+    {
+        var binding = new Binding();
+        var act = () => binding.Transport = value;
+
+        act.Should().Throw<InvalidOperationException>();
+    }
 }


### PR DESCRIPTION
## Summary
- ensure Binding Scheme, Protocol, and Transport only allow schema-approved values
- list allowed Binding constants
- validate property setters and throw on invalid values
- test that invalid binding values throw

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694a27c0088331bdcbb7ec5de6eff6