### PR TITLE
Propagate Bicep scope into generated manifests

### DIFF
--- a/src/Aspirate.Shared/Models/Aspirate/KubernetesDeploymentData.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/KubernetesDeploymentData.cs
@@ -164,6 +164,21 @@ public class KubernetesDeploymentData
     public KubernetesDeploymentData SetDeployment(BicepResource? deployment)
     {
         Deployment = deployment;
+
+        if (deployment is BicepV1Resource v1 && v1.Scope?.ResourceGroup is { } rg)
+        {
+            Annotations ??= [];
+
+            if (!Annotations.ContainsKey("aspirate.io/bicep-resource-group"))
+            {
+                Annotations.Add("aspirate.io/bicep-resource-group", rg);
+            }
+            else
+            {
+                Annotations["aspirate.io/bicep-resource-group"] = rg;
+            }
+        }
+
         return this;
     }
 


### PR DESCRIPTION
## Summary
- attach `BicepV1Resource.Scope.resourceGroup` as an annotation during manifest generation

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build --verbosity minimal` *(fails: "argument ... is invalid")*

------
https://chatgpt.com/codex/tasks/task_e_68694d81aedc83318fbb1f08cc6adf75