### PR TITLE
Validate build section in container.v0 resources

### DIFF
--- a/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
+++ b/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
@@ -48,6 +48,11 @@ public class ManifestFileParserService(
                 continue;
             }
 
+            if (type == AspireComponentLiterals.Container && resourceElement.TryGetProperty("build", out _))
+            {
+                throw new InvalidOperationException($"{AspireComponentLiterals.Container} {resourceName} does not support property 'build'.");
+            }
+
             var rawBytes = Encoding.UTF8.GetBytes(resourceElement.GetRawText());
             var reader = new Utf8JsonReader(rawBytes);
 

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -330,6 +330,26 @@ public class ManifestFileParserServiceTest
         result["resource1"].Should().BeOfType<ContainerResource>();
     }
 
+    [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenContainerV0HasBuildSection()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "container-with-build.json";
+        fileSystem.AddFile(
+            manifestFile,
+            new("{\"resources\": {\"svc\": {\"type\": \"container.v0\", \"image\": \"img\", \"build\": {\"context\": \"./\", \"dockerfile\": \"Dockerfile\"}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*does not support property 'build'.");
+    }
+
     [Theory]
     [InlineData("pg-endtoend.json", 22)]
     [InlineData("sqlserver-endtoend.json", 4)]


### PR DESCRIPTION
## Summary
- validate container.v0 resources don't include a `build` section when parsing manifests
- add regression test for the new validation

## Testing
- `dotnet test` *(fails: 27 failed, 237 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6869536c33988331a7b140fd0032688e