### PR TITLE
Remove BindMount name from schema

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BindMount.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BindMount.cs
@@ -3,8 +3,10 @@ namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 
 public class BindMount
 {
-    [JsonPropertyName("name")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <summary>
+    /// Internal name used when generating manifests. Not part of the Aspire schema.
+    /// </summary>
+    [JsonIgnore]
     public string? Name { get; set; }
 
     [JsonPropertyName("source")]


### PR DESCRIPTION
## Summary
- mark `BindMount.Name` as non-schema and ignore when (de)serializing

## Testing
- `dotnet test --no-build` *(fails: argument invalid)*
- `dotnet build Aspirate.sln --no-restore` *(fails: .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_686956c908388331b2696421fb7b69f0