### PR TITLE
Remove unnecessary template-path validation

### DIFF
--- a/src/Aspirate.Processors/Resources/Aws/CloudFormationStackProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Aws/CloudFormationStackProcessor.cs
@@ -28,13 +28,6 @@ public class CloudFormationStackProcessor(IFileSystem fileSystem, IAnsiConsole c
                 $"{AspireComponentLiterals.AwsCloudFormationStack} missing required property 'stack-name'.");
         }
 
-        if (!element.TryGetProperty("template-path", out var templatePath) ||
-            string.IsNullOrWhiteSpace(templatePath.GetString()))
-        {
-            throw new InvalidOperationException(
-                $"{AspireComponentLiterals.AwsCloudFormationStack} missing required property 'template-path'.");
-        }
-
         if (element.TryGetProperty("references", out var references) &&
             references.ValueKind == JsonValueKind.Array)
         {

--- a/tests/Aspirate.Tests/ProcessorTests/CloudFormationStackProcessorTests.cs
+++ b/tests/Aspirate.Tests/ProcessorTests/CloudFormationStackProcessorTests.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using Aspirate.Processors.Resources.Aws;
+using Xunit;
+
+namespace Aspirate.Tests.ProcessorTests;
+
+public class CloudFormationStackProcessorTests
+{
+    [Fact]
+    public void Deserialize_AllowsMissingTemplatePath()
+    {
+        // Arrange
+        var json = "{\"stack-name\":\"demo\"}";
+        var processor = new CloudFormationStackProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());
+        var reader = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(json));
+        reader.Read(); // start object
+
+        // Act
+        var resource = processor.Deserialize(ref reader) as CloudFormationStackResource;
+
+        // Assert
+        resource.StackName.Should().Be("demo");
+        resource.References.Should().BeNull();
+        resource.AdditionalProperties.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- cloudformation stack validation no longer enforces `template-path`
- add processor test to ensure template path is optional
- assert additional properties remain null when template path is omitted

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --verbosity normal` *(fails: 27 tests failed)*
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build --filter FullyQualifiedName~CloudFormationStackProcessorTests`

------
https://chatgpt.com/codex/tasks/task_e_6869f0f1069c83319908778277c76bd8