### PR TITLE
Restrict BuildSecret type to env or file

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BuildSecret.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BuildSecret.cs
@@ -1,11 +1,22 @@
+using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
 namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 
+public enum BuildSecretType
+{
+    [EnumMember(Value = "env")]
+    Env,
+
+    [EnumMember(Value = "file")]
+    File,
+}
+
 public class BuildSecret
 {
     [JsonPropertyName("type")]
-    public required string Type { get; set; }
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public required BuildSecretType Type { get; set; }
 
     [JsonPropertyName("value")]
     public string? Value { get; set; }

--- a/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
@@ -193,7 +193,7 @@ public class ContainerCompositionServiceTest
                 Dockerfile = "./Dockerfile",
                 Secrets = new()
                 {
-                    ["MY_SECRET"] = new BuildSecret { Type = "file", Source = "./secret.txt" }
+                    ["MY_SECRET"] = new BuildSecret { Type = BuildSecretType.File, Source = "./secret.txt" }
                 }
             }
         };
@@ -285,7 +285,7 @@ public class ContainerCompositionServiceTest
                 Dockerfile = "./Dockerfile",
                 Secrets = new()
                 {
-                    ["MY_SECRET"] = new BuildSecret { Type = "env" }
+                    ["MY_SECRET"] = new BuildSecret { Type = BuildSecretType.Env }
                 }
             }
         };
@@ -325,7 +325,7 @@ public class ContainerCompositionServiceTest
                 Dockerfile = "./Dockerfile",
                 Secrets = new()
                 {
-                    ["MY_SECRET"] = new BuildSecret { Type = "file" }
+                    ["MY_SECRET"] = new BuildSecret { Type = BuildSecretType.File }
                 }
             }
         };


### PR DESCRIPTION
## Summary
- enforce valid secret types with new `BuildSecretType` enum
- update container secret handling to use enum
- adjust service tests for new enum

## Testing
- `dotnet test` *(fails: Failed: 27, Passed: 238)*

------
https://chatgpt.com/codex/tasks/task_e_6869f519acbc8331a6da2f55e1c59cf2