### PR TITLE
Validate parameter input type

### DIFF
--- a/src/Aspirate.Shared/Literals/ParameterInputLiterals.cs
+++ b/src/Aspirate.Shared/Literals/ParameterInputLiterals.cs
@@ -1,0 +1,7 @@
+namespace Aspirate.Shared.Literals;
+
+[ExcludeFromCodeCoverage]
+public static class ParameterInputLiterals
+{
+    public const string String = "string";
+}

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ParameterInput.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ParameterInput.cs
@@ -3,12 +3,33 @@
 [ExcludeFromCodeCoverage]
 public class ParameterInput
 {
+    private string? _type;
+
     [JsonPropertyName("type")]
-    public string? Type { get; set; }
+    public string? Type
+    {
+        get => _type;
+        set => _type = ValidateType(value);
+    }
 
     [JsonPropertyName("default")]
     public ParameterDefault? Default { get; set; }
 
     [JsonPropertyName("secret")]
     public bool Secret { get; set; }
+
+    private static string? ValidateType(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (!string.Equals(value, ParameterInputLiterals.String, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Parameter input type must be '{ParameterInputLiterals.String}'.");
+        }
+
+        return value;
+    }
 }

--- a/tests/Aspirate.Tests/ActionsTests/Secrets/PopulateInputsActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Secrets/PopulateInputsActionTests.cs
@@ -164,38 +164,12 @@ public class PopulateInputsActionTests : BaseActionTests<PopulateInputsAction>
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidInputType_ThrowsActionCausesExitException()
+    public void ParameterInput_InvalidType_Throws()
     {
-        // Arrange
-        var console = new TestConsole();
-        console.Profile.Capabilities.Interactive = false;
-        var state = CreateAspirateState(nonInteractive: true);
-        var parameter = new ParameterResource
-        {
-            Name = "badparam",
-            Type = "string",
-            Inputs = new Dictionary<string, ParameterInput>
-            {
-                ["value"] = new()
-                {
-                    Type = "number"
-                }
-            }
-        };
-        state.LoadedAspireManifestResources = new Dictionary<string, Resource>
-        {
-            ["badparam"] = parameter
-        };
-        state.AspireComponentsToProcess = ["badparam"];
+        var input = new ParameterInput();
 
-        var serviceProvider = CreateServiceProvider(state, console);
-        var action = GetSystemUnderTest(serviceProvider);
+        var act = () => input.Type = "number";
 
-        // Act
-        var act = () => action.ExecuteAsync();
-
-        // Assert
-        await act.Should().ThrowAsync<ActionCausesExitException>();
-        console.Output.Should().Contain("Invalid parameter input type 'number'");
+        act.Should().Throw<InvalidOperationException>();
     }
 }

--- a/tests/Aspirate.Tests/ModelTests/ParameterInputSerializationTests.cs
+++ b/tests/Aspirate.Tests/ModelTests/ParameterInputSerializationTests.cs
@@ -1,0 +1,28 @@
+using Xunit;
+
+namespace Aspirate.Tests.ModelTests;
+
+public class ParameterInputSerializationTests
+{
+    [Theory]
+    [InlineData("number")]
+    [InlineData("bool")]
+    public void Setting_Invalid_Type_Throws(string value)
+    {
+        var input = new ParameterInput();
+        var act = () => input.Type = value;
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Deserializing_Invalid_Type_Throws()
+    {
+        var json = "{\"type\":\"number\"}";
+
+        var act = () => JsonSerializer.Deserialize<ParameterInput>(json);
+
+        act.Should().Throw<JsonException>()
+            .WithInnerException<InvalidOperationException>();
+    }
+}


### PR DESCRIPTION
## Summary
- enforce the allowed parameter input type value
- test invalid input handling early during runtime

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_6869f71a0078833181d7fba88214765e