### PR TITLE
Validate dapr manifest on parse

### DIFF
--- a/src/Aspirate.Processors/Resources/Dapr/DaprProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Dapr/DaprProcessor.cs
@@ -8,8 +8,12 @@ public class DaprProcessor(
 {
     public override string ResourceType => AspireComponentLiterals.DaprSystem;
 
-    public override Resource? Deserialize(ref Utf8JsonReader reader) =>
-        JsonSerializer.Deserialize<DaprResource>(ref reader);
+    public override Resource? Deserialize(ref Utf8JsonReader reader)
+    {
+        var resource = JsonSerializer.Deserialize<DaprResource>(ref reader);
+        ValidateDaprResource(resource, string.Empty);
+        return resource;
+    }
 
     public override Task<bool> CreateManifests(CreateManifestsOptions options) =>
         // Do nothing for dapr, they are there for annotations on services.

--- a/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
+++ b/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
@@ -176,4 +176,80 @@ public class RequiredPropertyValidationTests
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*missing required property 'components'");
     }
+
+    [Fact]
+    public void DaprProcessor_DeserializeMissingMetadata_Throws()
+    {
+        var processor = new DaprProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());
+
+        var json = "{}";
+
+        var act = () =>
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+            var r = new Utf8JsonReader(bytes);
+            r.Read();
+            processor.Deserialize(ref r);
+        };
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'metadata'");
+    }
+
+    [Fact]
+    public void DaprProcessor_DeserializeMissingApplication_Throws()
+    {
+        var processor = new DaprProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());
+
+        var json = "{\"dapr\":{\"appId\":\"id\",\"components\":[\"comp\"]}}";
+
+        var act = () =>
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+            var r = new Utf8JsonReader(bytes);
+            r.Read();
+            processor.Deserialize(ref r);
+        };
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'application'");
+    }
+
+    [Fact]
+    public void DaprProcessor_DeserializeMissingAppId_Throws()
+    {
+        var processor = new DaprProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());
+
+        var json = "{\"dapr\":{\"application\":\"app\",\"components\":[\"comp\"]}}";
+
+        var act = () =>
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+            var r = new Utf8JsonReader(bytes);
+            r.Read();
+            processor.Deserialize(ref r);
+        };
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'appId'");
+    }
+
+    [Fact]
+    public void DaprProcessor_DeserializeMissingComponents_Throws()
+    {
+        var processor = new DaprProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());
+
+        var json = "{\"dapr\":{\"application\":\"app\",\"appId\":\"id\"}}";
+
+        var act = () =>
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+            var r = new Utf8JsonReader(bytes);
+            r.Read();
+            processor.Deserialize(ref r);
+        };
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'components'");
+    }
 }


### PR DESCRIPTION
## Summary
- validate Dapr resource metadata during parsing
- add deserialization tests for invalid Dapr resources

## Testing
- `dotnet test` *(fails: The test suite reports many failures)*

------
https://chatgpt.com/codex/tasks/task_e_6869f935dafc8331afa4662b272bad15