### PR TITLE
Validate resources object in manifest parser

### DIFF
--- a/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
+++ b/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
@@ -31,7 +31,7 @@ public class ManifestFileParserService(
 
         if (!jsonObject.TryGetProperty("resources", out var resourcesElement) || resourcesElement.ValueKind != JsonValueKind.Object)
         {
-            return resources;
+            throw new InvalidOperationException("The manifest file does not contain a 'resources' object.");
         }
 
         foreach (var resourceProperty in resourcesElement.EnumerateObject())

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -46,7 +46,7 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
-    public void LoadAndParseAspireManifest_ReturnsEmptyDictionary_WhenManifestFileIsEmpty()
+    public void LoadAndParseAspireManifest_ThrowsException_WhenResourcesObjectMissing()
     {
         // Arrange
         var fileSystem = new MockFileSystem();
@@ -56,10 +56,11 @@ public class ManifestFileParserServiceTest
         var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
 
         // Act
-        var result = service.LoadAndParseAspireManifest(manifestFile);
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
 
         // Assert
-        result.Should().BeEmpty();
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("The manifest file does not contain a 'resources' object.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- validate `resources` object exists when parsing manifests
- expect an exception when the manifest is missing `resources`

## Testing
- `dotnet test tests/Aspirate.Tests --filter LoadAndParseAspireManifest_ThrowsException_WhenResourcesObjectMissing`

------
https://chatgpt.com/codex/tasks/task_e_6869fced0ca0833185899f3cafc245f4