### PR TITLE
Add path validation for project resources

### DIFF
--- a/src/Aspirate.Processors/Resources/Project/BaseProjectProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Project/BaseProjectProcessor.cs
@@ -21,8 +21,25 @@ public abstract class BaseProjectProcessor(
     private readonly Dictionary<string, MsBuildContainerProperties> _containerDetailsCache = [];
 
     /// <inheritdoc />
-    public override Resource? Deserialize(ref Utf8JsonReader reader) =>
-        JsonSerializer.Deserialize<ProjectResource>(ref reader);
+    public override Resource? Deserialize(ref Utf8JsonReader reader)
+    {
+        var project = JsonSerializer.Deserialize<ProjectResource>(ref reader);
+        ValidateProjectResource(project);
+        return project;
+    }
+
+    protected static void ValidateProjectResource(ProjectResource? project)
+    {
+        if (project is null)
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.Project} not found.");
+        }
+
+        if (string.IsNullOrWhiteSpace(project.Path))
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.Project} {project.Name} missing required property 'path'.");
+        }
+    }
 
     public override Task<bool> CreateManifests(CreateManifestsOptions options)
     {

--- a/src/Aspirate.Processors/Resources/Project/ProjectV1Processor.cs
+++ b/src/Aspirate.Processors/Resources/Project/ProjectV1Processor.cs
@@ -23,6 +23,10 @@ public sealed class ProjectV1Processor(
     public override string ResourceType => AspireComponentLiterals.ProjectV1;
 
     /// <inheritdoc />
-    public override Resource? Deserialize(ref Utf8JsonReader reader) =>
-        JsonSerializer.Deserialize<ProjectV1Resource>(ref reader);
+    public override Resource? Deserialize(ref Utf8JsonReader reader)
+    {
+        var project = JsonSerializer.Deserialize<ProjectV1Resource>(ref reader);
+        ValidateProjectResource(project);
+        return project;
+    }
 }

--- a/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
+++ b/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Xunit;
+using Aspirate.Processors.Resources.Project;
 
 namespace Aspirate.Tests.ProcessorTests;
 
@@ -251,5 +252,30 @@ public class RequiredPropertyValidationTests
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*missing required property 'components'");
+    }
+
+    [Fact]
+    public void ProjectProcessor_DeserializeMissingPath_Throws()
+    {
+        var processor = new ProjectProcessor(
+            Substitute.For<IFileSystem>(),
+            Substitute.For<IAnsiConsole>(),
+            Substitute.For<ISecretProvider>(),
+            Substitute.For<IContainerCompositionService>(),
+            Substitute.For<IContainerDetailsService>(),
+            Substitute.For<IManifestWriter>());
+
+        var json = "{}";
+
+        var act = () =>
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+            var r = new Utf8JsonReader(bytes);
+            r.Read();
+            processor.Deserialize(ref r);
+        };
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'path'");
     }
 }


### PR DESCRIPTION
## Summary
- validate project path when deserializing project resources
- propagate validation to ProjectV1Processor
- test missing `path` during project deserialization

## Testing
- `dotnet build Aspirate.sln --no-restore`
- `dotnet test Aspirate.sln --no-build --verbosity minimal` *(fails: 33 failed, 240 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6869fe455b20833195e391a7cb540588