### PR TITLE
Ensure read-only flag validation for containers

### DIFF
--- a/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
@@ -64,6 +64,11 @@ public abstract class BaseContainerProcessor<TContainerResource>(
             {
                 throw new InvalidOperationException($"{AspireComponentLiterals.Container} {name} volume missing required property 'target'.");
             }
+
+            if (volume.ReadOnly is null)
+            {
+                throw new InvalidOperationException($"{AspireComponentLiterals.Container} {name} volume missing required property 'readOnly'.");
+            }
         }
 
         foreach (var mount in container.BindMounts)
@@ -76,6 +81,11 @@ public abstract class BaseContainerProcessor<TContainerResource>(
             if (string.IsNullOrWhiteSpace(mount.Target))
             {
                 throw new InvalidOperationException($"{AspireComponentLiterals.Container} {name} bindMount missing required property 'target'.");
+            }
+
+            if (mount.ReadOnly is null)
+            {
+                throw new InvalidOperationException($"{AspireComponentLiterals.Container} {name} bindMount missing required property 'readOnly'.");
             }
         }
     }

--- a/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
@@ -100,7 +100,7 @@ public static class KubernetesDeploymentDataExtensions
                     MountPath = x.Target,
                 };
 
-                if (x.ReadOnly)
+                if (x.ReadOnly == true)
                 {
                     mount.ReadOnlyProperty = true;
                 }
@@ -115,7 +115,7 @@ public static class KubernetesDeploymentDataExtensions
             {
                 Name = x.Name,
                 MountPath = x.Target,
-                ReadOnlyProperty = x.ReadOnly,
+                ReadOnlyProperty = x.ReadOnly == true,
             }));
         }
 

--- a/src/Aspirate.Shared/Extensions/ResourceExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/ResourceExtensions.cs
@@ -62,6 +62,11 @@ public static class ResourceExtensions
                 throw new InvalidOperationException($"Volume missing required property 'name'.");
             }
 
+            if (volume.ReadOnly is null)
+            {
+                throw new InvalidOperationException($"Volume missing required property 'readOnly'.");
+            }
+
             volume.Name = volume.Name.Replace("/", "-").Replace(".", "-").Replace("--", "-").ToLowerInvariant();
         }
 
@@ -87,6 +92,11 @@ public static class ResourceExtensions
             if (string.IsNullOrWhiteSpace(mount.Target))
             {
                 throw new InvalidOperationException($"BindMount missing required property 'target'.");
+            }
+
+            if (mount.ReadOnly is null)
+            {
+                throw new InvalidOperationException($"BindMount missing required property 'readOnly'.");
             }
 
             if (string.IsNullOrWhiteSpace(mount.Name))
@@ -131,7 +141,7 @@ public static class ResourceExtensions
             KuberizeBindMountNames(resourceWithBindMounts.BindMounts, resource);
             composeVolumes.AddRange(resourceWithBindMounts.BindMounts?
                 .Where(x => !string.IsNullOrWhiteSpace(x.Source) && !string.IsNullOrWhiteSpace(x.Target))
-                .Select(m => $"{m.Source}:{m.Target}{(m.ReadOnly ? ":ro" : string.Empty)}") ?? []);
+                .Select(m => $"{m.Source}:{m.Target}{(m.ReadOnly == true ? ":ro" : string.Empty)}") ?? []);
         }
 
         return composeVolumes.ToArray();

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BindMount.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BindMount.cs
@@ -16,6 +16,6 @@ public class BindMount
     public string? Target { get; set; }
 
     [JsonPropertyName("readOnly")]
-    public bool ReadOnly { get; set; }
+    public bool? ReadOnly { get; set; }
 }
 

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Volume.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Volume.cs
@@ -9,5 +9,5 @@ public class Volume
     public string? Target { get; set; }
 
     [JsonPropertyName("readOnly")]
-    public bool ReadOnly { get; set; }
+    public bool? ReadOnly { get; set; }
 }

--- a/tests/Aspirate.Tests/ExtensionTests/KubernetesDeploymentDataExtensionTests.cs
+++ b/tests/Aspirate.Tests/ExtensionTests/KubernetesDeploymentDataExtensionTests.cs
@@ -163,7 +163,7 @@ public class KubernetesDeploymentDataExtensionTests
         var data = new KubernetesDeploymentData()
             .SetName("test")
             .SetContainerImage("test-image")
-            .SetVolumes(new List<Volume> { new Volume { Name = "test-volume", Target = "/data" } });
+            .SetVolumes(new List<Volume> { new Volume { Name = "test-volume", Target = "/data", ReadOnly = false } });
 
         // Act
         var result = data.ToKubernetesStatefulSet();
@@ -183,7 +183,7 @@ public class KubernetesDeploymentDataExtensionTests
         var data = new KubernetesDeploymentData()
             .SetName("test")
             .SetContainerImage("test-image")
-            .SetBindMounts(new List<BindMount> { new BindMount { Name = "host", Source = "/host", Target = "/data" } });
+            .SetBindMounts(new List<BindMount> { new BindMount { Name = "host", Source = "/host", Target = "/data", ReadOnly = false } });
 
         // Act
         var result = data.ToKubernetesDeployment();
@@ -200,7 +200,7 @@ public class KubernetesDeploymentDataExtensionTests
         var data = new KubernetesDeploymentData()
             .SetName("test")
             .SetContainerImage("test-image")
-            .SetBindMounts(new List<BindMount> { new BindMount { Source = "/logs", Target = "/data" } });
+            .SetBindMounts(new List<BindMount> { new BindMount { Source = "/logs", Target = "/data", ReadOnly = false } });
 
         // Act
         var result = data.ToKubernetesDeployment();
@@ -234,7 +234,7 @@ public class KubernetesDeploymentDataExtensionTests
         var data = new KubernetesDeploymentData()
             .SetName("test")
             .SetContainerImage("img")
-            .SetVolumes(new List<Volume> { new Volume { Target = "/data" } });
+            .SetVolumes(new List<Volume> { new Volume { Target = "/data", ReadOnly = false } });
 
         Action act = () => data.ToKubernetesStatefulSet();
 
@@ -248,7 +248,7 @@ public class KubernetesDeploymentDataExtensionTests
         var data = new KubernetesDeploymentData()
             .SetName("test")
             .SetContainerImage("img")
-            .SetBindMounts(new List<BindMount> { new BindMount { Name = "host", Source = "/host" } });
+            .SetBindMounts(new List<BindMount> { new BindMount { Name = "host", Source = "/host", ReadOnly = false } });
 
         Action act = () => data.ToKubernetesDeployment();
 

--- a/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
+++ b/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
@@ -89,6 +89,50 @@ public class RequiredPropertyValidationTests
     }
 
     [Fact]
+    public void ContainerProcessor_MissingVolumeReadOnly_Throws()
+    {
+        var processor = new ContainerProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<ISecretProvider>(), Substitute.For<IContainerCompositionService>(), Substitute.For<IContainerDetailsService>(), Substitute.For<IManifestWriter>());
+
+        var resource = new ContainerResource
+        {
+            Image = "img",
+            Volumes = new List<Volume> { new Volume { Name = "data", Target = "/data" } }
+        };
+
+        var options = new CreateComposeEntryOptions
+        {
+            Resource = new("cache", resource),
+        };
+
+        var act = () => processor.CreateComposeEntry(options);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'readOnly'");
+    }
+
+    [Fact]
+    public void ContainerProcessor_MissingBindMountReadOnly_Throws()
+    {
+        var processor = new ContainerProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<ISecretProvider>(), Substitute.For<IContainerCompositionService>(), Substitute.For<IContainerDetailsService>(), Substitute.For<IManifestWriter>());
+
+        var resource = new ContainerResource
+        {
+            Image = "img",
+            BindMounts = new List<BindMount> { new BindMount { Source = "/host", Target = "/data" } }
+        };
+
+        var options = new CreateComposeEntryOptions
+        {
+            Resource = new("cache", resource),
+        };
+
+        var act = () => processor.CreateComposeEntry(options);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'readOnly'");
+    }
+
+    [Fact]
     public void ExecutableProcessor_MissingCommand_Throws()
     {
         var processor = new ExecutableProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());


### PR DESCRIPTION
## Summary
- require `readOnly` property on volumes and bind mounts
- handle nullable flag in deployment helpers
- update container validation to check for missing `readOnly`
- adjust KubernetesDeploymentData tests
- add tests that verify validation of the flag

## Testing
- `dotnet test` *(fails: 35 tests, 240 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686a00d08fb48331a76ba449b0700860