### PR TITLE
Add validation for executable working directory

### DIFF
--- a/src/Aspirate.Processors/Resources/Executable/ExecutableProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Executable/ExecutableProcessor.cs
@@ -22,6 +22,11 @@ public class ExecutableProcessor(
         {
             throw new InvalidOperationException($"{AspireComponentLiterals.Executable} {name} missing required property 'command'.");
         }
+
+        if (string.IsNullOrWhiteSpace(exec.WorkingDirectory))
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.Executable} {name} missing required property 'workingDirectory'.");
+        }
     }
 
     public override Task<bool> CreateManifests(CreateManifestsOptions options) =>

--- a/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
+++ b/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
@@ -151,6 +151,24 @@ public class RequiredPropertyValidationTests
     }
 
     [Fact]
+    public void ExecutableProcessor_MissingWorkingDirectory_Throws()
+    {
+        var processor = new ExecutableProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());
+
+        var resource = new ExecutableResource { Command = "cmd" };
+
+        var options = new CreateComposeEntryOptions
+        {
+            Resource = new("exec", resource),
+        };
+
+        var act = () => processor.CreateComposeEntry(options);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'workingDirectory'");
+    }
+
+    [Fact]
     public void DaprProcessor_MissingMetadata_Throws()
     {
         var processor = new DaprProcessor(Substitute.For<IFileSystem>(), Substitute.For<IAnsiConsole>(), Substitute.For<IManifestWriter>());


### PR DESCRIPTION
## Summary
- ensure `ExecutableProcessor.ValidateExecutable` checks `workingDirectory`
- cover missing `workingDirectory` with a new unit test

## Testing
- `dotnet build Aspirate.sln`
- `dotnet test --no-build` *(fails: ParameterProcessorTests.Deserialize_MissingInputType_Throws, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_686a076629ac8331899b7a6a00729765