### PR TITLE
Add validation for Bicep processors

### DIFF
--- a/src/Aspirate.Processors/Resources/Azure/BicepProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Azure/BicepProcessor.cs
@@ -11,8 +11,25 @@ public class BicepProcessor(IFileSystem fileSystem, IAnsiConsole console,
     public override string ResourceType => AspireComponentLiterals.AzureBicep;
 
     /// <inheritdoc />
-    public override Resource? Deserialize(ref Utf8JsonReader reader) =>
-        JsonSerializer.Deserialize<BicepResource>(ref reader);
+    public override Resource? Deserialize(ref Utf8JsonReader reader)
+    {
+        var resource = JsonSerializer.Deserialize<BicepResource>(ref reader);
+        ValidateBicepResource(resource, string.Empty);
+        return resource;
+    }
+
+    private static void ValidateBicepResource(BicepResource? resource, string name)
+    {
+        if (resource is null)
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.AzureBicep} {name} not found.");
+        }
+
+        if (string.IsNullOrWhiteSpace(resource.Path))
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.AzureBicep} {name} missing required property 'path'.");
+        }
+    }
 
     public override Task<bool> CreateManifests(CreateManifestsOptions options) =>
         // Do nothing, bicep resources are preserved only.

--- a/src/Aspirate.Processors/Resources/Azure/BicepV1Processor.cs
+++ b/src/Aspirate.Processors/Resources/Azure/BicepV1Processor.cs
@@ -11,8 +11,25 @@ public class BicepV1Processor(IFileSystem fileSystem, IAnsiConsole console,
     public override string ResourceType => AspireComponentLiterals.AzureBicepV1;
 
     /// <inheritdoc />
-    public override Resource? Deserialize(ref Utf8JsonReader reader) =>
-        JsonSerializer.Deserialize<BicepV1Resource>(ref reader);
+    public override Resource? Deserialize(ref Utf8JsonReader reader)
+    {
+        var resource = JsonSerializer.Deserialize<BicepV1Resource>(ref reader);
+        ValidateBicepResource(resource, string.Empty);
+        return resource;
+    }
+
+    private static void ValidateBicepResource(BicepResource? resource, string name)
+    {
+        if (resource is null)
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.AzureBicepV1} {name} not found.");
+        }
+
+        if (string.IsNullOrWhiteSpace(resource.Path))
+        {
+            throw new InvalidOperationException($"{AspireComponentLiterals.AzureBicepV1} {name} missing required property 'path'.");
+        }
+    }
 
     public override Task<bool> CreateManifests(CreateManifestsOptions options) =>
         // Do nothing, bicep resources are preserved only.

--- a/tests/Aspirate.Tests/GlobalUsings.cs
+++ b/tests/Aspirate.Tests/GlobalUsings.cs
@@ -43,6 +43,7 @@ global using Aspirate.Processors.Resources.Dockerfile;
 global using Aspirate.Processors.Resources.AbstractProcessors;
 global using Aspirate.Processors.Resources.Executable;
 global using Aspirate.Processors.Resources.Dapr;
+global using Aspirate.Processors.Resources.Azure;
 global using ContainerResource = Aspirate.Shared.Models.AspireManifests.Components.V0.Container.ContainerResource;
 global using ContainerV1Resource = Aspirate.Shared.Models.AspireManifests.Components.V1.Container.ContainerV1Resource;
 global using ProjectV1Resource = Aspirate.Shared.Models.AspireManifests.Components.V1.Project.ProjectV1Resource;

--- a/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
+++ b/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
@@ -340,4 +340,48 @@ public class RequiredPropertyValidationTests
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*missing required property 'path'");
     }
+
+    [Fact]
+    public void BicepProcessor_DeserializeMissingPath_Throws()
+    {
+        var processor = new BicepProcessor(
+            Substitute.For<IFileSystem>(),
+            Substitute.For<IAnsiConsole>(),
+            Substitute.For<IManifestWriter>());
+
+        var json = "{}";
+
+        var act = () =>
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+            var r = new Utf8JsonReader(bytes);
+            r.Read();
+            processor.Deserialize(ref r);
+        };
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'path'");
+    }
+
+    [Fact]
+    public void BicepV1Processor_DeserializeMissingPath_Throws()
+    {
+        var processor = new BicepV1Processor(
+            Substitute.For<IFileSystem>(),
+            Substitute.For<IAnsiConsole>(),
+            Substitute.For<IManifestWriter>());
+
+        var json = "{}";
+
+        var act = () =>
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+            var r = new Utf8JsonReader(bytes);
+            r.Read();
+            processor.Deserialize(ref r);
+        };
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required property 'path'");
+    }
 }


### PR DESCRIPTION
## Summary
- validate `path` when deserializing Azure bicep resources
- cover BicepProcessor and BicepV1Processor missing path cases

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686a092705c483319c2ba9b238bbeb97