### PR TITLE
Enforce binding field presence

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Binding.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Binding.cs
@@ -5,10 +5,10 @@ namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 /// </summary>
 
 [ExcludeFromCodeCoverage]
-public class Binding
+public class Binding : IJsonOnDeserialized
 {
-    private string? _scheme = BindingLiterals.Http;
-    private string? _protocol = BindingLiterals.Tcp;
+    private string? _scheme;
+    private string? _protocol;
     private string? _transport;
 
     /// <summary>
@@ -58,6 +58,24 @@ public class Binding
     /// </summary>
     [JsonPropertyName("external")]
     public bool External { get; set; }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (string.IsNullOrWhiteSpace(_scheme))
+        {
+            throw new InvalidOperationException("Scheme is required for a binding.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_protocol))
+        {
+            throw new InvalidOperationException("Protocol is required for a binding.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_transport))
+        {
+            throw new InvalidOperationException("Transport is required for a binding.");
+        }
+    }
 
     private static string? Validate(string? value, string propertyName, IReadOnlyCollection<string> validValues)
     {


### PR DESCRIPTION
## Summary
- ensure `Binding` fields `Scheme`, `Protocol` and `Transport` are required after deserialization
- remove default scheme and protocol values so the manifest must supply them

## Testing
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_686a0cc5a9d88331807905adb277b62d