### PR TITLE
Add missing transport binding validation test

### DIFF
--- a/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
+++ b/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Text.Json.Nodes;
+using Aspirate.Processors.Transformation.Bindings;
 using Xunit;
 using Aspirate.Processors.Resources.Project;
 
@@ -130,6 +132,20 @@ public class RequiredPropertyValidationTests
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*missing required property 'readOnly'");
+    }
+
+    [Fact]
+    public void ContainerProcessor_DeserializeMissingTransport_Throws()
+    {
+        var bindingProcessor = new BindingProcessor();
+
+        var json = "{\"pg\":{\"image\":\"img\",\"bindings\":{\"tcp\":{\"scheme\":\"tcp\",\"protocol\":\"tcp\"}}}}";
+        var node = JsonNode.Parse(json);
+
+        var act = () => bindingProcessor.ParseBinding(["pg", "bindings", "tcp", "port"], node);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Transport is required for a binding.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- extend RequiredPropertyValidationTests with a case for bindings missing transport
- parse binding via `BindingProcessor` and verify the expected InvalidOperationException

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --filter "FullyQualifiedName~ContainerProcessor_DeserializeMissingTransport_Throws"`
- `dotnet test` *(fails: 40 failed, 242 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686a0e0072808331b531c0670edd49b1