### PR TITLE
Improve Parameter default validation

### DIFF
--- a/src/Aspirate.Processors/Resources/AbstractProcessors/ParameterProcessor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/ParameterProcessor.cs
@@ -76,10 +76,58 @@ public class ParameterProcessor(IFileSystem fileSystem, IAnsiConsole console,
                 $"{AspireComponentLiterals.Parameter} {parameterName} input '{inputName}' default must specify either 'generate' or 'value'.");
         }
 
-        if (hasGenerate && defaultValue.Generate!.MinLength <= 0)
+        if (hasGenerate)
         {
-            throw new InvalidOperationException(
-                $"{AspireComponentLiterals.Parameter} {parameterName} input '{inputName}' generate.minLength must be greater than 0.");
+            var generate = defaultValue.Generate!;
+
+            if (generate.MinLength <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"{AspireComponentLiterals.Parameter} {parameterName} input '{inputName}' generate.minLength must be greater than 0.");
+            }
+
+            if (!generate.Lower && !generate.Upper && !generate.Numeric && !generate.Special)
+            {
+                throw new InvalidOperationException(
+                    $"{AspireComponentLiterals.Parameter} {parameterName} input '{inputName}' generate must allow at least one character type.");
+            }
+
+            if (generate.MinLower < 0 || generate.MinUpper < 0 || generate.MinNumeric < 0 || generate.MinSpecial < 0)
+            {
+                throw new InvalidOperationException(
+                    $"{AspireComponentLiterals.Parameter} {parameterName} input '{inputName}' generate minimum counts cannot be negative.");
+            }
+
+            if (!generate.Lower && generate.MinLower > 0)
+            {
+                throw new InvalidOperationException(
+                    $"{AspireComponentLiterals.Parameter} {parameterName} input '{inputName}' generate.minLower requires lower to be true.");
+            }
+
+            if (!generate.Upper && generate.MinUpper > 0)
+            {
+                throw new InvalidOperationException(
+                    $"{AspireComponentLiterals.Parameter} {parameterName} input '{inputName}' generate.minUpper requires upper to be true.");
+            }
+
+            if (!generate.Numeric && generate.MinNumeric > 0)
+            {
+                throw new InvalidOperationException(
+                    $"{AspireComponentLiterals.Parameter} {parameterName} input '{inputName}' generate.minNumeric requires numeric to be true.");
+            }
+
+            if (!generate.Special && generate.MinSpecial > 0)
+            {
+                throw new InvalidOperationException(
+                    $"{AspireComponentLiterals.Parameter} {parameterName} input '{inputName}' generate.minSpecial requires special to be true.");
+            }
+
+            var totalMin = generate.MinLower + generate.MinUpper + generate.MinNumeric + generate.MinSpecial;
+            if (totalMin > generate.MinLength)
+            {
+                throw new InvalidOperationException(
+                    $"{AspireComponentLiterals.Parameter} {parameterName} input '{inputName}' sum of minimum counts cannot exceed minLength.");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- validate password generator options when reading parameter resources
- add more unit tests for bad parameter defaults
- adjust test expectations for errors

## Testing
- `dotnet test --filter FullyQualifiedName~ParameterProcessorTests`
- `dotnet test` *(fails: ContainerCompositionServiceTest.BuildAndPushContainerForDockerfile_InvalidEnvSecret_Throws)*

------
https://chatgpt.com/codex/tasks/task_e_686a19bc81348331a2415541002c6bdc