### PR TITLE
Add file secret path validation

### DIFF
--- a/src/Aspirate.Services/Implementations/ContainerCompositionService.cs
+++ b/src/Aspirate.Services/Implementations/ContainerCompositionService.cs
@@ -274,7 +274,7 @@ public sealed class ContainerCompositionService(
         }
     }
 
-    private static void ValidateSecrets(Dictionary<string, BuildSecret> secrets)
+    private void ValidateSecrets(Dictionary<string, BuildSecret> secrets)
     {
         foreach (var (key, secret) in secrets)
         {
@@ -292,6 +292,10 @@ public sealed class ContainerCompositionService(
                     if (string.IsNullOrWhiteSpace(secret.Source))
                     {
                         throw new InvalidOperationException($"Build secret '{key}' of type 'file' requires a source.");
+                    }
+                    if (!filesystem.File.Exists(secret.Source))
+                    {
+                        throw new InvalidOperationException($"Build secret '{key}' file '{secret.Source}' does not exist.");
                     }
                     break;
                 default:

--- a/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
@@ -342,6 +342,46 @@ public class ContainerCompositionServiceTest
         await action.Should().ThrowAsync<InvalidOperationException>();
     }
 
+    [Theory]
+    [InlineData("docker")]
+    [InlineData("podman")]
+    [InlineData("nerdctl")]
+    public async Task BuildAndPushContainerForDockerfile_FileSecretPathMissing_Throws(string builder)
+    {
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddFile("./Dockerfile", string.Empty);
+        var console = new TestConsole();
+        var projectPropertyService = Substitute.For<IProjectPropertyService>();
+        var shellExecutionService = Substitute.For<IShellExecutionService>();
+
+        var service = new ContainerCompositionService(fileSystem, console, projectPropertyService, shellExecutionService);
+
+        var resource = new ContainerV1Resource
+        {
+            Name = "testresource",
+            Build = new()
+            {
+                Context = "ctx",
+                Dockerfile = "./Dockerfile",
+                Secrets = new()
+                {
+                    ["MY_SECRET"] = new BuildSecret { Type = BuildSecretType.File, Source = "./missing.txt" }
+                }
+            }
+        };
+
+        shellExecutionService.IsCommandAvailable(Arg.Any<string>()).Returns(CommandAvailableResult.Available(builder));
+
+        var action = () => service.BuildAndPushContainerForDockerfile(resource, new()
+        {
+            ContainerBuilder = builder,
+            ImageName = "img",
+            Registry = "reg"
+        }, nonInteractive: true);
+
+        await action.Should().ThrowAsync<InvalidOperationException>();
+    }
+
    private static void VerifyDockerCall(ICall call, string expectedArgumentsOutput, string builder)
    {
         if (call.GetArguments()[0] is not ShellCommandOptions options)


### PR DESCRIPTION
## Summary
- validate file secrets paths using the `IFileSystem` in `ContainerCompositionService`
- add tests for missing file secret paths

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686a1c7a09b483318e30e78cf57e9018