### PR TITLE
Align resource discriminators with manifest schema

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Resource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Resource.cs
@@ -1,3 +1,5 @@
+using Aspirate.Shared.Literals;
+
 namespace Aspirate.Shared.Models.AspireManifests;
 
 /// <summary>
@@ -5,16 +7,16 @@ namespace Aspirate.Shared.Models.AspireManifests;
 /// </summary>
 [ExcludeFromCodeCoverage]
 [JsonPolymorphic]
-[JsonDerivedType(typeof(ProjectResource), typeDiscriminator: "aspire.project")]
-[JsonDerivedType(typeof(ProjectV1Resource), typeDiscriminator: "aspire.project.v1")]
-[JsonDerivedType(typeof(DockerfileResource), typeDiscriminator: "aspire.dockerfile")]
-[JsonDerivedType(typeof(ContainerResource), typeDiscriminator: "aspire.container")]
-[JsonDerivedType(typeof(ContainerV1Resource), typeDiscriminator: "aspire.container.v1")]
-[JsonDerivedType(typeof(DaprResource), typeDiscriminator: "aspire.dapr")]
-[JsonDerivedType(typeof(DaprComponentResource), typeDiscriminator: "aspire.daprcomponent")]
-[JsonDerivedType(typeof(ParameterResource), typeDiscriminator: "aspire.parameter")]
-[JsonDerivedType(typeof(ValueResource), typeDiscriminator: "aspire.value")]
-[JsonDerivedType(typeof(ExecutableResource), typeDiscriminator: "aspire.executable")]
+[JsonDerivedType(typeof(ProjectResource), typeDiscriminator: AspireComponentLiterals.Project)]
+[JsonDerivedType(typeof(ProjectV1Resource), typeDiscriminator: AspireComponentLiterals.ProjectV1)]
+[JsonDerivedType(typeof(DockerfileResource), typeDiscriminator: AspireComponentLiterals.Dockerfile)]
+[JsonDerivedType(typeof(ContainerResource), typeDiscriminator: AspireComponentLiterals.Container)]
+[JsonDerivedType(typeof(ContainerV1Resource), typeDiscriminator: AspireComponentLiterals.ContainerV1)]
+[JsonDerivedType(typeof(DaprResource), typeDiscriminator: AspireComponentLiterals.DaprSystem)]
+[JsonDerivedType(typeof(DaprComponentResource), typeDiscriminator: AspireComponentLiterals.DaprComponent)]
+[JsonDerivedType(typeof(ParameterResource), typeDiscriminator: AspireComponentLiterals.Parameter)]
+[JsonDerivedType(typeof(ValueResource), typeDiscriminator: AspireComponentLiterals.Value)]
+[JsonDerivedType(typeof(ExecutableResource), typeDiscriminator: AspireComponentLiterals.Executable)]
 [JsonDerivedType(typeof(BicepResource), typeDiscriminator: "azure.bicep.v0")]
 [JsonDerivedType(typeof(BicepV1Resource), typeDiscriminator: "azure.bicep.v1")]
 [JsonDerivedType(typeof(CloudFormationStackResource), typeDiscriminator: "aws.cloudformation.stack.v0")]

--- a/tests/Aspirate.Tests/ModelTests/ResourceDiscriminatorTests.cs
+++ b/tests/Aspirate.Tests/ModelTests/ResourceDiscriminatorTests.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Aspirate.Tests.ModelTests;
+
+public class ResourceDiscriminatorTests
+{
+    public static IEnumerable<object[]> ResourceData => new List<object[]>
+    {
+        new object[] { new ProjectResource(), AspireComponentLiterals.Project, typeof(ProjectResource) },
+        new object[] { new ProjectV1Resource(), AspireComponentLiterals.ProjectV1, typeof(ProjectV1Resource) },
+        new object[] { new DockerfileResource(), AspireComponentLiterals.Dockerfile, typeof(DockerfileResource) },
+        new object[] { new ContainerResource { Image = "img" }, AspireComponentLiterals.Container, typeof(ContainerResource) },
+        new object[] { new ContainerV1Resource { Image = "img" }, AspireComponentLiterals.ContainerV1, typeof(ContainerV1Resource) },
+        new object[] { new DaprResource(), AspireComponentLiterals.DaprSystem, typeof(DaprResource) },
+        new object[] { new DaprComponentResource(), AspireComponentLiterals.DaprComponent, typeof(DaprComponentResource) },
+        new object[] { new ParameterResource(), AspireComponentLiterals.Parameter, typeof(ParameterResource) },
+        new object[] { new ValueResource { ConnectionString = "c" }, AspireComponentLiterals.Value, typeof(ValueResource) },
+        new object[] { new ExecutableResource(), AspireComponentLiterals.Executable, typeof(ExecutableResource) },
+        new object[] { new BicepResource(), AspireComponentLiterals.AzureBicep, typeof(BicepResource) },
+        new object[] { new BicepV1Resource(), AspireComponentLiterals.AzureBicepV1, typeof(BicepV1Resource) },
+        new object[] { new CloudFormationStackResource(), AspireComponentLiterals.AwsCloudFormationStack, typeof(CloudFormationStackResource) },
+        new object[] { new CloudFormationTemplateResource(), AspireComponentLiterals.AwsCloudFormationTemplate, typeof(CloudFormationTemplateResource) },
+    };
+
+    [Theory]
+    [MemberData(nameof(ResourceData))]
+    public void Resource_Serializes_WithSchemaType(Resource resource, string expectedType, Type expected)
+    {
+        resource.Type = expectedType;
+        var json = JsonSerializer.Serialize<Resource>(resource);
+        json.Should().Contain($"\"type\":\"{expectedType}\"");
+
+        var roundTrip = JsonSerializer.Deserialize<Resource>(json)!;
+        roundTrip.Should().BeOfType(expected);
+    }
+}


### PR DESCRIPTION
## Summary
- use schema strings for `JsonDerivedType` discriminators
- add tests covering resource discriminator serialization/deserialization

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a213fc6c08331b0d70bf56e913a4d