### PR TITLE
Handle manifest base directory

### DIFF
--- a/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromDockerfilesAction.cs
+++ b/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromDockerfilesAction.cs
@@ -132,7 +132,7 @@ public sealed class BuildAndPushContainersFromDockerfilesAction(
                     Registry = CurrentState.ContainerRegistry,
                     Prefix = CurrentState.ContainerRepositoryPrefix,
                     Tags = CurrentState.ContainerImageTags
-                }, CurrentState.NonInteractive);
+                }, CurrentState.NonInteractive, CurrentState.ManifestDirectory);
         }
     }
 

--- a/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs
+++ b/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs
@@ -34,7 +34,7 @@ public sealed class BuildAndPushContainersFromProjectsAction(
                 BuildArgs = CurrentState.ContainerBuildArgs?.ToDictionary(arg => arg.Split('=')[0], arg => arg.Split('=')[1]),
                 BuildContext = CurrentState.ContainerBuildContext,
                 Tags = CurrentState.ContainerImageTags
-            }, CurrentState.NonInteractive, CurrentState.RuntimeIdentifier, CurrentState.PreferDockerfile);
+            }, CurrentState.NonInteractive, CurrentState.RuntimeIdentifier, CurrentState.PreferDockerfile, CurrentState.ManifestDirectory);
         }
 
         Logger.MarkupLine("[bold]Building and push completed for all selected project components.[/]");

--- a/src/Aspirate.Commands/Actions/Containers/PopulateContainerDetailsForProjectsAction.cs
+++ b/src/Aspirate.Commands/Actions/Containers/PopulateContainerDetailsForProjectsAction.cs
@@ -35,7 +35,7 @@ public sealed class PopulateContainerDetailsForProjectsAction(
                 Registry = CurrentState.ContainerRegistry,
                 Prefix = CurrentState.ContainerRepositoryPrefix,
                 Tags = CurrentState.ContainerImageTags,
-            });
+            }, CurrentState.ManifestDirectory);
         }
     }
 

--- a/src/Aspirate.Commands/Actions/Manifests/LoadAspireManifestAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/LoadAspireManifestAction.cs
@@ -10,6 +10,7 @@ public class LoadAspireManifestAction(
 
         var aspireManifest = manifestFileParserService.LoadAndParseAspireManifest(CurrentState.AspireManifest);
         CurrentState.LoadedAspireManifestResources = aspireManifest;
+        CurrentState.ManifestDirectory = manifestFileParserService.ManifestDirectory;
 
         SelectManifestItemsToProcess();
 

--- a/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
@@ -179,7 +179,7 @@ public abstract class BaseContainerProcessor<TContainerResource>(
             .ApplyIngress(options)
             .Validate();
 
-    public async Task BuildAndPushContainerForDockerfile(KeyValuePair<string, Resource> resource, ContainerOptions options, bool nonInteractive)
+    public async Task BuildAndPushContainerForDockerfile(KeyValuePair<string, Resource> resource, ContainerOptions options, bool nonInteractive, string? basePath = null)
     {
         if (resource.Value is not ContainerV1Resource containerV1 || containerV1.Build == null)
         {
@@ -188,7 +188,7 @@ public abstract class BaseContainerProcessor<TContainerResource>(
 
         ValidateContainerResource(containerV1, resource.Key);
 
-        await containerCompositionService.BuildAndPushContainerForDockerfile(containerV1, options, nonInteractive);
+        await containerCompositionService.BuildAndPushContainerForDockerfile(containerV1, options, nonInteractive, basePath);
 
         _console.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Building and Pushing container for Dockerfile [blue]{resource.Key}[/]");
     }
@@ -223,8 +223,8 @@ public abstract class BaseContainerProcessor<TContainerResource>(
             {
                 service.WithBuild(builder =>
                     builder
-                        .WithContext(_fileSystem.GetFullPath(containerV1.Build.Context))
-                        .WithDockerfile(_fileSystem.GetFullPath(containerV1.Build.Dockerfile))
+                        .WithContext(_fileSystem.GetFullPath(containerV1.Build.Context, options.CurrentState?.ManifestDirectory))
+                        .WithDockerfile(_fileSystem.GetFullPath(containerV1.Build.Dockerfile, options.CurrentState?.ManifestDirectory))
                         .Build());
             }
         }

--- a/src/Aspirate.Processors/Resources/Project/BaseProjectProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Project/BaseProjectProcessor.cs
@@ -89,7 +89,7 @@ public abstract class BaseProjectProcessor(
             .Validate();
     }
 
-    public async Task BuildAndPushProjectContainer(KeyValuePair<string, Resource> resource, ContainerOptions options, bool nonInteractive, string? runtimeIdentifier, bool preferDockerfile)
+    public async Task BuildAndPushProjectContainer(KeyValuePair<string, Resource> resource, ContainerOptions options, bool nonInteractive, string? runtimeIdentifier, bool preferDockerfile, string? basePath = null)
     {
         var project = resource.Value as ProjectResource;
 
@@ -114,21 +114,21 @@ public abstract class BaseProjectProcessor(
                 BuildArgs = options.BuildArgs
             };
 
-            await containerCompositionService.BuildAndPushContainerForDockerfile(dockerfileResource, options, nonInteractive);
+            await containerCompositionService.BuildAndPushContainerForDockerfile(dockerfileResource, options, nonInteractive, basePath);
         }
         else
         {
-            await containerCompositionService.BuildAndPushContainerForProject(project, containerDetails, options, nonInteractive, runtimeIdentifier);
+            await containerCompositionService.BuildAndPushContainerForProject(project, containerDetails, options, nonInteractive, runtimeIdentifier, basePath);
         }
 
         _console.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Building and Pushing container for project [blue]{resource.Key}[/]");
     }
 
-    public async Task PopulateContainerDetailsCacheForProject(KeyValuePair<string, Resource> resource, ContainerOptions options)
+    public async Task PopulateContainerDetailsCacheForProject(KeyValuePair<string, Resource> resource, ContainerOptions options, string? basePath = null)
     {
         var project = resource.Value as ProjectResource;
 
-        var details = await containerDetailsService.GetContainerDetails(resource.Key, project, options);
+        var details = await containerDetailsService.GetContainerDetails(resource.Key, project, options, basePath);
 
         var success = _containerDetailsCache.TryAdd(resource.Key, details);
 

--- a/src/Aspirate.Services/Implementations/ContainerDetailsService.cs
+++ b/src/Aspirate.Services/Implementations/ContainerDetailsService.cs
@@ -1,16 +1,17 @@
 namespace Aspirate.Services.Implementations;
 
-public class ContainerDetailsService(IProjectPropertyService propertyService, IAnsiConsole console) : IContainerDetailsService
+public class ContainerDetailsService(IProjectPropertyService propertyService, IAnsiConsole console, IFileSystem fileSystem) : IContainerDetailsService
 {
     private static readonly StringBuilder _imageBuilder = new();
 
     public async Task<MsBuildContainerProperties> GetContainerDetails(
         string resourceName,
         ProjectResource projectResource,
-        ContainerOptions options)
+        ContainerOptions options,
+        string? basePath = null)
     {
         var containerPropertiesJson = await propertyService.GetProjectPropertiesAsync(
-            projectResource.Path,
+            fileSystem.NormalizePath(projectResource.Path, basePath),
             ContainerBuilderLiterals.ContainerRegistry,
             ContainerBuilderLiterals.ContainerRepository,
             ContainerBuilderLiterals.ContainerImageName,

--- a/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
+++ b/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
@@ -15,6 +15,8 @@ public class ManifestFileParserService(
     IAnsiConsole console,
     IServiceProvider serviceProvider) : IManifestFileParserService
 {
+    public string? ManifestDirectory { get; private set; }
+
     private static readonly Dictionary<string, HashSet<string>> _allowedProperties = new(StringComparer.OrdinalIgnoreCase)
     {
         [AspireComponentLiterals.Dockerfile] = new(
@@ -154,6 +156,8 @@ public class ManifestFileParserService(
         {
             throw new InvalidOperationException($"The manifest file could not be loaded from: '{manifestFile}'");
         }
+
+        ManifestDirectory = fileSystem.Path.GetDirectoryName(fileSystem.GetFullPath(manifestFile));
 
         var inputJson = fileSystem.File.ReadAllText(manifestFile);
 

--- a/src/Aspirate.Services/Implementations/ProjectPropertyService.cs
+++ b/src/Aspirate.Services/Implementations/ProjectPropertyService.cs
@@ -2,9 +2,9 @@ namespace Aspirate.Services.Implementations;
 
 public sealed class ProjectPropertyService(IFileSystem filesystem, IShellExecutionService shellExecutionService, IAnsiConsole console) : IProjectPropertyService
 {
-    public async Task<string?> GetProjectPropertiesAsync(string projectPath, params string[] propertyNames)
+    public async Task<string?> GetProjectPropertiesAsync(string projectPath, string? basePath = null, params string[] propertyNames)
     {
-        var fullProjectPath = filesystem.NormalizePath(projectPath);
+        var fullProjectPath = filesystem.NormalizePath(projectPath, basePath);
         var propertyValues = await ExecuteDotnetMsBuildGetPropertyCommand(fullProjectPath, propertyNames);
 
         return propertyValues ?? null;

--- a/src/Aspirate.Shared/Interfaces/Processors/IImageProcessor.cs
+++ b/src/Aspirate.Shared/Interfaces/Processors/IImageProcessor.cs
@@ -8,11 +8,13 @@ public interface IImageProcessor
     /// <param name="resource">The resource containing information about the docker file.</param>
     /// <param name="options">The container options.</param>
     /// <param name="nonInteractive">Flag indicating whether the process should run in non-interactive mode.</param>
+    /// <param name="basePath">The base directory of the manifest.</param>
     /// <returns>A task representing an asynchronous operation.</returns>
     Task BuildAndPushContainerForDockerfile(
         KeyValuePair<string, Resource> resource,
         ContainerOptions options,
-        bool nonInteractive);
+        bool nonInteractive,
+        string? basePath = null);
 
     /// <summary>
     /// Populates a container cache with names generated from options.

--- a/src/Aspirate.Shared/Interfaces/Services/IContainerCompositionService.cs
+++ b/src/Aspirate.Shared/Interfaces/Services/IContainerCompositionService.cs
@@ -13,6 +13,7 @@ public interface IContainerCompositionService
     /// <param name="options">Container options.</param>
     /// <param name="nonInteractive">Flag indicating whether the process should run in non-interactive mode.</param>
     /// <param name="runtimeIdentifier">The runtime identifier to use for project builds.</param>
+    /// <param name="basePath">The base directory of the manifest.</param>
     /// <returns>
     /// A task representing the asynchronous operation. The task result will be true if the container build and push was successful,
     /// or false if there was an error during the process.
@@ -21,7 +22,8 @@ public interface IContainerCompositionService
         MsBuildContainerProperties containerDetails,
         ContainerOptions options,
         bool nonInteractive = false,
-        string? runtimeIdentifier = null);
+        string? runtimeIdentifier = null,
+        string? basePath = null);
 
     /// <summary>
     /// Build and push a container for a Dockerfile.
@@ -39,7 +41,12 @@ public interface IContainerCompositionService
     /// It then pushes the created image to the specified registry.
     /// The nonInteractive parameter can be set to true to suppress any interactive prompts during the build process.
     /// </remarks>
-    Task<bool> BuildAndPushContainerForDockerfile(DockerfileResource dockerfileResource, ContainerOptions options, bool? nonInteractive);
+    /// <param name="basePath">The base directory of the manifest.</param>
+    Task<bool> BuildAndPushContainerForDockerfile(DockerfileResource dockerfileResource, ContainerOptions options, bool? nonInteractive, string? basePath = null);
 
-    Task<bool> BuildAndPushContainerForDockerfile(ContainerV1Resource containerV1Resource, ContainerOptions options, bool? nonInteractive);
+    /// <param name="containerV1Resource">The container resource to build.</param>
+    /// <param name="options">The build options.</param>
+    /// <param name="nonInteractive">Indicates if the build should be non-interactive.</param>
+    /// <param name="basePath">The base directory of the manifest.</param>
+    Task<bool> BuildAndPushContainerForDockerfile(ContainerV1Resource containerV1Resource, ContainerOptions options, bool? nonInteractive, string? basePath = null);
 }

--- a/src/Aspirate.Shared/Interfaces/Services/IContainerDetailsService.cs
+++ b/src/Aspirate.Shared/Interfaces/Services/IContainerDetailsService.cs
@@ -11,6 +11,7 @@ public interface IContainerDetailsService
     /// <param name="resourceName">The name of the resource.</param>
     /// <param name="projectResource">The project instance.</param>
     /// <param name="options">Container options.</param>
+    /// <param name="basePath">The base directory of the manifest.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="MsBuildContainerProperties"/> object.</returns>
-    Task<MsBuildContainerProperties> GetContainerDetails(string resourceName, ProjectResource projectResource, ContainerOptions options);
+    Task<MsBuildContainerProperties> GetContainerDetails(string resourceName, ProjectResource projectResource, ContainerOptions options, string? basePath = null);
 }

--- a/src/Aspirate.Shared/Interfaces/Services/IManifestFileParserService.cs
+++ b/src/Aspirate.Shared/Interfaces/Services/IManifestFileParserService.cs
@@ -6,6 +6,11 @@ namespace Aspirate.Shared.Interfaces.Services;
 public interface IManifestFileParserService
 {
     /// <summary>
+    /// Gets the directory path of the loaded manifest file.
+    /// </summary>
+    string? ManifestDirectory { get; }
+
+    /// <summary>
     /// Loads and parses an Aspire manifest file.
     /// </summary>
     /// <param name="manifestFile">Path to the manifest file</param>

--- a/src/Aspirate.Shared/Interfaces/Services/IProjectPropertyService.cs
+++ b/src/Aspirate.Shared/Interfaces/Services/IProjectPropertyService.cs
@@ -10,10 +10,11 @@ public interface IProjectPropertyService
     /// </summary>
     /// <param name="projectPath">The path to the project.</param>
     /// <param name="propertyNames">The names of the properties to retrieve.</param>
+    /// <param name="basePath">The base directory of the manifest.</param>
     /// <returns>
     /// A task that represents the asynchronous operation. The task result contains a string array
     /// that contains the values of the specified properties. If a property does not exist or
     /// cannot be retrieved, its value in the result array will be null.
     /// </returns>
-    Task<string?> GetProjectPropertiesAsync(string projectPath, params string[] propertyNames);
+    Task<string?> GetProjectPropertiesAsync(string projectPath, string? basePath = null, params string[] propertyNames);
 }

--- a/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
@@ -209,6 +209,9 @@ public class AspirateState :
     [JsonIgnore]
     public string? SecretPassword { get; set; }
 
+    [JsonIgnore]
+    public string? ManifestDirectory { get; set; }
+
     public void AppendToFinalResources(string key, Resource resource) =>
         FinalResources.Add(key, resource);
 

--- a/tests/Aspirate.Tests/GlobalUsings.cs
+++ b/tests/Aspirate.Tests/GlobalUsings.cs
@@ -44,6 +44,7 @@ global using Aspirate.Processors.Resources.AbstractProcessors;
 global using Aspirate.Processors.Resources.Executable;
 global using Aspirate.Processors.Resources.Dapr;
 global using Aspirate.Processors.Resources.Azure;
+global using Aspirate.Shared.Models.AspireManifests.Components.Azure;
 global using ContainerResource = Aspirate.Shared.Models.AspireManifests.Components.V0.Container.ContainerResource;
 global using ContainerV1Resource = Aspirate.Shared.Models.AspireManifests.Components.V1.Container.ContainerV1Resource;
 global using ProjectV1Resource = Aspirate.Shared.Models.AspireManifests.Components.V1.Project.ProjectV1Resource;

--- a/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
@@ -45,7 +45,7 @@ public class ContainerCompositionServiceTest
             ImageName = imageName,
             Registry = registry,
             Prefix = prefix,
-        }, nonInteractive: true);
+        }, nonInteractive: true, basePath: null);
 
         // Assert
         shellExecutionService.Received(1).IsCommandAvailable(Arg.Any<string>());
@@ -96,7 +96,7 @@ public class ContainerCompositionServiceTest
             ContainerBuilder = builder,
             ImageName = "testImageName",
             Registry = "testRegistry",
-        }, nonInteractive: true);
+        }, nonInteractive: true, basePath: null);
 
         // Assert
         var testFile = fileSystem.Path.GetFullPath("./testDockerfile");
@@ -154,7 +154,7 @@ public class ContainerCompositionServiceTest
             ImageName = "testImageName",
             Registry = "testRegistry",
             Prefix = "testPrefix",
-        }, nonInteractive: true);
+        }, nonInteractive: true, basePath: null);
 
         // Assert
         var testFile = fileSystem.Path.GetFullPath("./testDockerfile");
@@ -215,7 +215,7 @@ public class ContainerCompositionServiceTest
             ContainerBuilder = builder,
             ImageName = "testimage",
             Registry = "testregistry",
-        }, nonInteractive: true);
+        }, nonInteractive: true, basePath: null);
 
         // Assert
         var dockerfilePath = fileSystem.Path.GetFullPath("./Dockerfile");
@@ -256,7 +256,7 @@ public class ContainerCompositionServiceTest
             ContainerBuilder = builder,
             ImageName = imageName,
             Registry = registry,
-        }, nonInteractive: true);
+        }, nonInteractive: true, basePath: null);
 
         // Assert
         await action.Should().ThrowAsync<ActionCausesExitException>();
@@ -297,7 +297,7 @@ public class ContainerCompositionServiceTest
             ContainerBuilder = builder,
             ImageName = "img",
             Registry = "reg"
-        }, nonInteractive: true);
+        }, nonInteractive: true, basePath: null);
 
         await action.Should().ThrowAsync<InvalidOperationException>();
     }
@@ -337,7 +337,7 @@ public class ContainerCompositionServiceTest
             ContainerBuilder = builder,
             ImageName = "img",
             Registry = "reg"
-        }, nonInteractive: true);
+        }, nonInteractive: true, basePath: null);
 
         await action.Should().ThrowAsync<InvalidOperationException>();
     }
@@ -377,7 +377,7 @@ public class ContainerCompositionServiceTest
             ContainerBuilder = builder,
             ImageName = "img",
             Registry = "reg"
-        }, nonInteractive: true);
+        }, nonInteractive: true, basePath: null);
 
         await action.Should().ThrowAsync<InvalidOperationException>();
     }

--- a/tests/Aspirate.Tests/ServiceTests/ContainerDetailsServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ContainerDetailsServiceTests.cs
@@ -18,14 +18,23 @@ public class ContainerDetailsServiceTests
         // Arrange
         var projectPropertyService = Substitute.For<IProjectPropertyService>();
         var testConsole = new TestConsole();
+        var fileSystem = Substitute.For<IFileSystem>();
 
         var responseJson = JsonSerializer.Serialize(properties.Properties);
 
         projectPropertyService
-            .GetProjectPropertiesAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .GetProjectPropertiesAsync(
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>())
             .ReturnsForAnyArgs(responseJson);
 
-        var containerDetailsService = new ContainerDetailsService(projectPropertyService, testConsole);
+        var containerDetailsService = new ContainerDetailsService(projectPropertyService, testConsole, fileSystem);
 
         if (properties.Parameters is null)
         {
@@ -33,7 +42,7 @@ public class ContainerDetailsServiceTests
         }
 
         // Act
-        var containerDetails = await containerDetailsService.GetContainerDetails("test-service", new(), properties.Parameters);
+        var containerDetails = await containerDetailsService.GetContainerDetails("test-service", new(), properties.Parameters, null);
 
         // Assert
         await Verify(containerDetails)

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -31,6 +31,20 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
+    public void LoadAndParseAspireManifest_SetsManifestDirectory()
+    {
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddFile("/manifests/manifest.json", new("{\"resources\": {}}"));
+        fileSystem.Directory.SetCurrentDirectory("/other");
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        service.LoadAndParseAspireManifest("/manifests/manifest.json");
+
+        service.ManifestDirectory.Should().Be("/manifests");
+    }
+
+    [Fact]
     public void LoadAndParseAspireManifest_ThrowsException_WhenManifestFileDoesNotExist()
     {
         // Arrange

--- a/tests/Aspirate.Tests/ServiceTests/ProjectPropertyServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ProjectPropertyServiceTests.cs
@@ -21,7 +21,7 @@ public class ProjectPropertyServiceTest
             .Returns(Task.FromResult(new ShellCommandResult(true, "test", string.Empty, 0)));
 
         // Act
-        var result = await service.GetProjectPropertiesAsync(projectPath, propertyNames);
+        var result = await service.GetProjectPropertiesAsync(projectPath, null, propertyNames);
 
         // Assert
         await shellExecutionService.Received(1).ExecuteCommand(Arg.Is<ShellCommandOptions>(options => options.Command != null && options.ArgumentsBuilder != null));


### PR DESCRIPTION
## Summary
- track manifest directory when parsing
- use manifest directory for path resolution
- allow container and project services to receive a base path
- update path helpers to accept base path
- add regression tests for manifest parser

## Testing
- `dotnet build Aspirate.sln`
- `dotnet test Aspirate.sln --no-build` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_686a22c2f2f48331bb82d671b07ef247