### PR TITLE
Handle invalid bicep deployment types

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Azure/BicepResourceConverter.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Azure/BicepResourceConverter.cs
@@ -19,14 +19,15 @@ internal class BicepResourceConverter : JsonConverter<BicepResource>
         }
         if (!doc.RootElement.TryGetProperty("type", out var typeElement))
         {
-            return doc.RootElement.Deserialize<BicepResource>(newOptions);
+            throw new InvalidOperationException("Deployment missing required property 'type'.");
         }
 
         var type = typeElement.GetString();
         return type switch
         {
+            AspireComponentLiterals.AzureBicep => doc.RootElement.Deserialize<BicepResource>(newOptions),
             AspireComponentLiterals.AzureBicepV1 => doc.RootElement.Deserialize<BicepV1Resource>(newOptions),
-            _ => doc.RootElement.Deserialize<BicepResource>(newOptions)
+            _ => throw new InvalidOperationException($"Deployment type '{type}' must be '{AspireComponentLiterals.AzureBicep}' or '{AspireComponentLiterals.AzureBicepV1}'.")
         };
     }
 

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -539,6 +539,46 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
+    public void ProjectV1Deployment_InvalidType_Throws()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "project-v1-deployment-invalid-type.json";
+        var testData = Path.Combine(AppContext.BaseDirectory, "TestData", manifestFile);
+        fileSystem.AddFile(manifestFile, new(File.ReadAllText(testData)));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Deployment type 'azure.bicep.bad' must be 'azure.bicep.v0' or 'azure.bicep.v1'.*");
+    }
+
+    [Fact]
+    public void ProjectV1Deployment_MissingType_Throws()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "project-v1-deployment-missing-type.json";
+        var testData = Path.Combine(AppContext.BaseDirectory, "TestData", manifestFile);
+        fileSystem.AddFile(manifestFile, new(File.ReadAllText(testData)));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Deployment missing required property 'type'.*");
+    }
+
+    [Fact]
     public async Task ContainerV1Deployment_BicepV0_ParsesSuccessfully()
     {
         // Arrange
@@ -560,6 +600,46 @@ public class ManifestFileParserServiceTest
         container.Deployment!.Path.Should().Be("./redis.bicep");
         container.Deployment.Should().BeOfType<BicepResource>();
         container.Deployment.Should().NotBeOfType<BicepV1Resource>();
+    }
+
+    [Fact]
+    public void ContainerV1Deployment_InvalidType_Throws()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "container-v1-deployment-invalid-type.json";
+        var testData = Path.Combine(AppContext.BaseDirectory, "TestData", manifestFile);
+        fileSystem.AddFile(manifestFile, new(File.ReadAllText(testData)));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Deployment type 'azure.bicep.bad' must be 'azure.bicep.v0' or 'azure.bicep.v1'.*");
+    }
+
+    [Fact]
+    public void ContainerV1Deployment_MissingType_Throws()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "container-v1-deployment-missing-type.json";
+        var testData = Path.Combine(AppContext.BaseDirectory, "TestData", manifestFile);
+        fileSystem.AddFile(manifestFile, new(File.ReadAllText(testData)));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Deployment missing required property 'type'.*");
     }
 
     [Fact]

--- a/tests/Aspirate.Tests/TestData/container-v1-deployment-invalid-type.json
+++ b/tests/Aspirate.Tests/TestData/container-v1-deployment-invalid-type.json
@@ -1,0 +1,15 @@
+{
+  "resources": {
+    "cache": {
+      "type": "container.v1",
+      "image": "redis:7.2.4",
+      "deployment": {
+        "type": "azure.bicep.bad",
+        "path": "./redis.bicep",
+        "scope": {
+          "resourceGroup": "rg-name"
+        }
+      }
+    }
+  }
+}

--- a/tests/Aspirate.Tests/TestData/container-v1-deployment-missing-type.json
+++ b/tests/Aspirate.Tests/TestData/container-v1-deployment-missing-type.json
@@ -1,0 +1,14 @@
+{
+  "resources": {
+    "cache": {
+      "type": "container.v1",
+      "image": "redis:7.2.4",
+      "deployment": {
+        "path": "./redis.bicep",
+        "scope": {
+          "resourceGroup": "rg-name"
+        }
+      }
+    }
+  }
+}

--- a/tests/Aspirate.Tests/TestData/project-v1-deployment-invalid-type.json
+++ b/tests/Aspirate.Tests/TestData/project-v1-deployment-invalid-type.json
@@ -1,0 +1,26 @@
+{
+  "resources": {
+    "app": {
+      "type": "project.v1",
+      "path": "../TestApp.csproj",
+      "bindings": {
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http",
+          "targetPort": 5050
+        }
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "deployment": {
+        "type": "azure.bicep.bad",
+        "path": "./redis.bicep",
+        "scope": {
+          "resourceGroup": "rg-name"
+        }
+      }
+    }
+  }
+}

--- a/tests/Aspirate.Tests/TestData/project-v1-deployment-missing-type.json
+++ b/tests/Aspirate.Tests/TestData/project-v1-deployment-missing-type.json
@@ -1,0 +1,25 @@
+{
+  "resources": {
+    "app": {
+      "type": "project.v1",
+      "path": "../TestApp.csproj",
+      "bindings": {
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http",
+          "targetPort": 5050
+        }
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "deployment": {
+        "path": "./redis.bicep",
+        "scope": {
+          "resourceGroup": "rg-name"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- check bicep deployment `type` when deserializing
- throw if deployment type is missing or unsupported
- test invalid/missing deployment types

## Testing
- `dotnet test -c Release` *(fails: Failed: 44, Passed: 267)*

------
https://chatgpt.com/codex/tasks/task_e_686a2fdabfe88331b30b785bb3d9abb4