### PR TITLE
Validate ParameterInput extension data

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ParameterInput.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ParameterInput.cs
@@ -1,7 +1,7 @@
 ﻿namespace Aspirate.Shared.Models.AspireManifests.Components.V0.Parameters;
 
 [ExcludeFromCodeCoverage]
-public class ParameterInput
+public class ParameterInput : IJsonOnDeserialized
 {
     private string? _type;
 
@@ -18,6 +18,9 @@ public class ParameterInput
     [JsonPropertyName("secret")]
     public bool Secret { get; set; }
 
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }
+
     private static string? ValidateType(string? value)
     {
         if (value is null)
@@ -31,5 +34,14 @@ public class ParameterInput
         }
 
         return value;
+    }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (AdditionalProperties is not null && AdditionalProperties.Count > 0)
+        {
+            var unexpected = AdditionalProperties.Keys.First();
+            throw new InvalidOperationException($"Parameter input unexpected property '{unexpected}'.");
+        }
     }
 }

--- a/tests/Aspirate.Tests/ModelTests/ParameterInputSerializationTests.cs
+++ b/tests/Aspirate.Tests/ModelTests/ParameterInputSerializationTests.cs
@@ -25,4 +25,16 @@ public class ParameterInputSerializationTests
         act.Should().Throw<JsonException>()
             .WithInnerException<InvalidOperationException>();
     }
+
+    [Fact]
+    public void Deserializing_With_Unknown_Property_Throws()
+    {
+        var json = "{\"type\":\"string\",\"extra\":true}";
+
+        var act = () => JsonSerializer.Deserialize<ParameterInput>(json);
+
+        act.Should().Throw<JsonException>()
+            .WithInnerException<InvalidOperationException>()
+            .WithMessage("*unexpected property 'extra'");
+    }
 }

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -340,6 +340,26 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenParameterInputHasUnknownProperty()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "parameter-input-extra.json";
+        fileSystem.AddFile(manifestFile,
+            new("{\"resources\": {\"param\": {\"type\": \"parameter.v0\", \"value\": \"foo\", \"inputs\": {\"value\": {\"type\": \"string\", \"extra\": true}}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        // Act
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        // Assert
+        act.Should().Throw<JsonException>()
+            .WithInnerException<InvalidOperationException>()
+            .WithMessage("*unexpected property 'extra'");
+    }
+
+    [Fact]
     public void LoadAndParseAspireManifest_ReturnsResource_WhenResourceTypeIsSupported()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- validate ParameterInput JSON fields
- throw when unexpected fields appear in ParameterInput
- test ParameterInput extra fields
- verify manifest parser throws when Parameter input has extra fields

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a322a357083319e3a0aba22b202ea