### PR TITLE
Ensure secrets cleared after container build

### DIFF
--- a/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
@@ -463,6 +463,55 @@ public class ContainerCompositionServiceTest
         await action.Should().ThrowAsync<InvalidOperationException>();
     }
 
+    [Theory]
+    [InlineData("docker")]
+    [InlineData("podman")]
+    [InlineData("nerdctl")]
+    public async Task BuildAndPushContainerForDockerfile_ClearsEnvSecrets(string builder)
+    {
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddFile("./Dockerfile", string.Empty);
+        var console = new TestConsole();
+        var projectPropertyService = Substitute.For<IProjectPropertyService>();
+        var shellExecutionService = Substitute.For<IShellExecutionService>();
+
+        var service = new ContainerCompositionService(fileSystem, console, projectPropertyService, shellExecutionService);
+
+        var resource = new ContainerV1Resource
+        {
+            Name = "testresource",
+            Build = new()
+            {
+                Context = "ctx",
+                Dockerfile = "./Dockerfile",
+                Secrets = new()
+                {
+                    ["MY_SECRET"] = new BuildSecret { Type = BuildSecretType.Env, Value = "val" }
+                }
+            }
+        };
+
+        var response = builder == "podman" ? PodmanInfoOutput : DockerInfoOutput;
+
+        shellExecutionService.ExecuteCommand(Arg.Is<ShellCommandOptions>(options => options.Command != null && options.ArgumentsBuilder != null))
+            .Returns(Task.FromResult(new ShellCommandResult(true, response, string.Empty, 0)));
+
+        shellExecutionService.ExecuteCommandWithEnvironmentNoOutput(Arg.Any<string>(), Arg.Any<ArgumentsBuilder>(), Arg.Any<Dictionary<string, string?>>())
+            .Returns(Task.FromResult(true));
+
+        shellExecutionService.IsCommandAvailable(Arg.Any<string>())
+            .Returns(CommandAvailableResult.Available(builder));
+
+        await service.BuildAndPushContainerForDockerfile(resource, new()
+        {
+            ContainerBuilder = builder,
+            ImageName = "img",
+            Registry = "reg"
+        }, nonInteractive: true, basePath: null);
+
+        Environment.GetEnvironmentVariable("MY_SECRET").Should().BeNull();
+    }
+
    private static void VerifyDockerCall(ICall call, string expectedArgumentsOutput, string builder)
    {
         if (call.GetArguments()[0] is not ShellCommandOptions options)


### PR DESCRIPTION
## Summary
- clean up env variables set for build secrets
- test env var cleanup

## Testing
- `dotnet test --verbosity minimal` *(fails: NETSDK1045 due to missing 9.0 SDK)*

------
https://chatgpt.com/codex/tasks/task_e_686a390ffb8883318612e11fa1881335