### PR TITLE
Add validation for build related manifest elements

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BindMount.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BindMount.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Serialization;
 namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 
-public class BindMount
+public class BindMount : IJsonOnDeserialized
 {
     /// <summary>
     /// Internal name used when generating manifests. Not part of the Aspire schema.
@@ -17,5 +17,17 @@ public class BindMount
 
     [JsonPropertyName("readOnly")]
     public bool? ReadOnly { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (AdditionalProperties is not null && AdditionalProperties.Count > 0)
+        {
+            var unexpected = AdditionalProperties.Keys.First();
+            throw new InvalidOperationException($"BindMount unexpected property '{unexpected}'.");
+        }
+    }
 }
 

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Build.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Build.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 
-public class Build
+public class Build : IJsonOnDeserialized
 {
     [JsonPropertyName("context")]
     public required string Context { get; set; }
@@ -15,4 +15,16 @@ public class Build
 
     [JsonPropertyName("secrets")]
     public Dictionary<string, BuildSecret>? Secrets { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (AdditionalProperties is not null && AdditionalProperties.Count > 0)
+        {
+            var unexpected = AdditionalProperties.Keys.First();
+            throw new InvalidOperationException($"Build unexpected property '{unexpected}'.");
+        }
+    }
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BuildSecret.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BuildSecret.cs
@@ -12,7 +12,7 @@ public enum BuildSecretType
     File,
 }
 
-public class BuildSecret
+public class BuildSecret : IJsonOnDeserialized
 {
     [JsonPropertyName("type")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -23,4 +23,16 @@ public class BuildSecret
 
     [JsonPropertyName("source")]
     public string? Source { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (AdditionalProperties is not null && AdditionalProperties.Count > 0)
+        {
+            var unexpected = AdditionalProperties.Keys.First();
+            throw new InvalidOperationException($"Build secret unexpected property '{unexpected}'.");
+        }
+    }
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Volume.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Volume.cs
@@ -1,6 +1,6 @@
 namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 
-public class Volume
+public class Volume : IJsonOnDeserialized
 {
     [JsonPropertyName("name")]
     public string? Name { get; set; }
@@ -10,4 +10,16 @@ public class Volume
 
     [JsonPropertyName("readOnly")]
     public bool? ReadOnly { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (AdditionalProperties is not null && AdditionalProperties.Count > 0)
+        {
+            var unexpected = AdditionalProperties.Keys.First();
+            throw new InvalidOperationException($"Volume unexpected property '{unexpected}'.");
+        }
+    }
 }

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -188,6 +188,66 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenBuildHasUnknownProperty()
+    {
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "build-extra.json";
+        fileSystem.AddFile(manifestFile, new("{\"resources\": {\"svc\": {\"type\": \"container.v1\", \"build\": {\"context\": \"./\", \"dockerfile\": \"Dockerfile\", \"extra\": true}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unexpected property 'extra'");
+    }
+
+    [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenBuildSecretHasUnknownProperty()
+    {
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "build-secret-extra.json";
+        fileSystem.AddFile(manifestFile, new("{\"resources\": {\"svc\": {\"type\": \"container.v1\", \"build\": {\"context\": \"./\", \"dockerfile\": \"Dockerfile\", \"secrets\": {\"MY_SECRET\": {\"type\": \"env\", \"extra\": true}}}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unexpected property 'extra'");
+    }
+
+    [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenVolumeHasUnknownProperty()
+    {
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "volume-extra.json";
+        fileSystem.AddFile(manifestFile, new("{\"resources\": {\"svc\": {\"type\": \"container.v1\", \"image\": \"img\", \"volumes\": [{\"name\": \"data\", \"target\": \"/data\", \"readOnly\": false, \"extra\": 1}]}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unexpected property 'extra'");
+    }
+
+    [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenBindMountHasUnknownProperty()
+    {
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "bindmount-extra.json";
+        fileSystem.AddFile(manifestFile, new("{\"resources\": {\"svc\": {\"type\": \"container.v1\", \"image\": \"img\", \"bindMounts\": [{\"source\": \"./src\", \"target\": \"/data\", \"readOnly\": true, \"extra\": 1}]}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unexpected property 'extra'");
+    }
+
+    [Fact]
     public void LoadAndParseAspireManifest_Throws_WhenCloudFormationStackMissingStackName()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- ensure Build, BuildSecret, Volume, and BindMount reject extra JSON properties
- test ManifestFileParserService for these new validations

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --verbosity minimal` *(fails: CS0104 ComposeService ambiguous)*

------
https://chatgpt.com/codex/tasks/task_e_686a428c2d808331ac74660afdb6d99e