### PR TITLE
Add Dapr metadata validation

### DIFF
--- a/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
@@ -202,9 +202,9 @@ public abstract class BaseContainerProcessor<TContainerResource>(
         _console.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Setting container details for Dockerfile [blue]{resource.Key}[/]");
     }
 
-    public override ComposeService CreateComposeEntry(CreateComposeEntryOptions options)
+    public override Aspirate.Shared.Models.Aspirate.ComposeService CreateComposeEntry(CreateComposeEntryOptions options)
     {
-        var response = new ComposeService();
+        var response = new Aspirate.Shared.Models.Aspirate.ComposeService();
 
         var container = options.Resource.Value as TContainerResource;
         ValidateContainerResource(container, options.Resource.Key);

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Dapr/ComponentMetadata.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Dapr/ComponentMetadata.cs
@@ -1,6 +1,6 @@
 namespace Aspirate.Shared.Models.AspireManifests.Components.V0.Dapr;
 
-public class Metadata
+public class Metadata : IJsonOnDeserialized
 {
     [JsonPropertyName("application")]
     public string Application { get; set; } = default!;
@@ -17,4 +17,13 @@ public class Metadata
     /// </summary>
     [JsonExtensionData]
     public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (ExtensionData is not null && ExtensionData.Count > 0)
+        {
+            var unexpected = ExtensionData.Keys.First();
+            throw new InvalidOperationException($"Dapr metadata unexpected property '{unexpected}'.");
+        }
+    }
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Dapr/InnerDaprComponent.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Dapr/InnerDaprComponent.cs
@@ -1,6 +1,6 @@
 namespace Aspirate.Shared.Models.AspireManifests.Components.V0.Dapr;
 
-public sealed class InnerDaprComponent
+public sealed class InnerDaprComponent : IJsonOnDeserialized
 {
     [JsonPropertyName("type")]
     public string? Type { get; set; }
@@ -66,6 +66,25 @@ public sealed class InnerDaprComponent
 
             AdditionalProperties ??= new();
             AdditionalProperties["metadata"] = JsonDocument.Parse(JsonSerializer.Serialize(value)).RootElement.Clone();
+        }
+    }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (AdditionalProperties is null)
+        {
+            return;
+        }
+
+        foreach (var key in AdditionalProperties.Keys)
+        {
+            if (string.Equals(key, "version", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(key, "metadata", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            throw new InvalidOperationException($"Dapr component unexpected property '{key}'.");
         }
     }
 }

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -420,6 +420,38 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenDaprMetadataHasUnknownProperty()
+    {
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "dapr-metadata-extra.json";
+        fileSystem.AddFile(manifestFile,
+            new("{\"resources\": {\"dapr\": {\"type\": \"dapr.v0\", \"dapr\": {\"application\": \"app\", \"appId\": \"id\", \"components\": [], \"foo\": true}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unexpected property 'foo'");
+    }
+
+    [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenDaprComponentHasUnknownProperty()
+    {
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "dapr-component-extra.json";
+        fileSystem.AddFile(manifestFile,
+            new("{\"resources\": {\"comp\": {\"type\": \"dapr.component.v0\", \"daprComponent\": {\"type\": \"state.redis\", \"foo\": \"bar\"}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unexpected property 'foo'");
+    }
+
+    [Fact]
     public void LoadAndParseAspireManifest_ReturnsResource_WhenResourceTypeIsSupported()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- detect unexpected fields in Dapr metadata and component objects
- test invalid dapr metadata and component fields
- fix ambiguous ComposeService usage

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj` *(fails: BuildBuilder missing WithSecrets)*

------
https://chatgpt.com/codex/tasks/task_e_686a45073f208331a40b9d31cf5c5cd5