### PR TITLE
Add unknown field validation

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Azure/BicepScope.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Azure/BicepScope.cs
@@ -1,11 +1,26 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace Aspirate.Shared.Models.AspireManifests.Components.Azure;
 
 /// <summary>
 /// Represents the scope for a bicep deployment.
 /// </summary>
-public class BicepScope
+public class BicepScope : IJsonOnDeserialized
 {
     [JsonPropertyName("resourceGroup")]
     public string? ResourceGroup { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (AdditionalProperties is not null && AdditionalProperties.Count > 0)
+        {
+            var unexpected = AdditionalProperties.Keys.First();
+            throw new InvalidOperationException($"Bicep scope unexpected property '{unexpected}'.");
+        }
+    }
 }
 

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/Generate.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/Generate.cs
@@ -1,7 +1,11 @@
-﻿namespace Aspirate.Shared.Models.AspireManifests.Components.V0.Parameters;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Aspirate.Shared.Models.AspireManifests.Components.V0.Parameters;
 
 [ExcludeFromCodeCoverage]
-public class Generate
+public class Generate : IJsonOnDeserialized
 {
     [JsonPropertyName("minLength")]
     public int MinLength { get; set; }
@@ -29,4 +33,17 @@ public class Generate
 
     [JsonPropertyName("minSpecial")]
     public int MinSpecial { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (AdditionalProperties is not null && AdditionalProperties.Count > 0)
+        {
+            var unexpected = AdditionalProperties.Keys.First();
+            throw new InvalidOperationException($"Generate unexpected property '{unexpected}'.");
+        }
+    }
 }
+

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ParameterDefault.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Parameters/ParameterDefault.cs
@@ -1,10 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace Aspirate.Shared.Models.AspireManifests.Components.V0.Parameters;
 
-public class ParameterDefault
+public class ParameterDefault : IJsonOnDeserialized
 {
     [JsonPropertyName("value")]
     public string? Value { get; set; }
 
     [JsonPropertyName("generate")]
     public Generate? Generate { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }
+
+    void IJsonOnDeserialized.OnDeserialized()
+    {
+        if (AdditionalProperties is not null && AdditionalProperties.Count > 0)
+        {
+            var unexpected = AdditionalProperties.Keys.First();
+            throw new InvalidOperationException($"Parameter default unexpected property '{unexpected}'.");
+        }
+    }
 }

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -420,6 +420,38 @@ public class ManifestFileParserServiceTest
     }
 
     [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenParameterDefaultHasUnknownProperty()
+    {
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "parameter-default-extra.json";
+        fileSystem.AddFile(manifestFile,
+            new("{\"resources\": {\"param\": {\"type\": \"parameter.v0\", \"value\": \"foo\", \"inputs\": {\"value\": {\"type\": \"string\", \"default\": {\"value\": \"bar\", \"extra\": true}}}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unexpected property 'extra'");
+    }
+
+    [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenGenerateHasUnknownProperty()
+    {
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "generate-extra.json";
+        fileSystem.AddFile(manifestFile,
+            new("{\"resources\": {\"param\": {\"type\": \"parameter.v0\", \"value\": \"foo\", \"inputs\": {\"value\": {\"type\": \"string\", \"default\": {\"generate\": {\"minLength\": 8, \"extra\": true}}}}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unexpected property 'extra'");
+    }
+
+    [Fact]
     public void LoadAndParseAspireManifest_Throws_WhenDaprMetadataHasUnknownProperty()
     {
         var fileSystem = new MockFileSystem();
@@ -752,6 +784,22 @@ public class ManifestFileParserServiceTest
         // Assert
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*Deployment missing required property 'type'.*");
+    }
+
+    [Fact]
+    public void LoadAndParseAspireManifest_Throws_WhenBicepScopeHasUnknownProperty()
+    {
+        var fileSystem = new MockFileSystem();
+        var manifestFile = "bicep-scope-extra.json";
+        fileSystem.AddFile(manifestFile,
+            new("{\"resources\": {\"bicep\": {\"type\": \"azure.bicep.v1\", \"path\": \"./b.bicep\", \"scope\": {\"resourceGroup\": \"rg\", \"extra\": true}}}}"));
+        var serviceProvider = CreateServiceProvider(fileSystem);
+        var service = serviceProvider.GetRequiredService<IManifestFileParserService>();
+
+        Action act = () => service.LoadAndParseAspireManifest(manifestFile);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unexpected property 'extra'");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- validate unexpected JSON properties for BicepScope, ParameterDefault and Generate
- test unexpected property handling for these objects

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a47a9e1f88331b404b791a0993611