### PR TITLE
Fix parameter input validation constant

### DIFF
--- a/src/Aspirate.Commands/Actions/Secrets/PopulateInputsAction.cs
+++ b/src/Aspirate.Commands/Actions/Secrets/PopulateInputsAction.cs
@@ -1,3 +1,5 @@
+using Aspirate.Shared.Literals;
+
 namespace Aspirate.Commands.Actions.Secrets;
 
 public sealed class PopulateInputsAction(
@@ -192,9 +194,9 @@ public sealed class PopulateInputsAction(
 
             foreach (var input in resource.Inputs)
             {
-                if (!string.Equals(input.Value.Type, "string", StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(input.Value.Type, ParameterInputLiterals.String, StringComparison.OrdinalIgnoreCase))
                 {
-                    Logger.ValidationFailed($"Invalid parameter input type '{input.Value.Type}' for '{resource.Name}.{input.Key}'. Only 'string' is supported.");
+                    Logger.ValidationFailed($"Invalid parameter input type '{input.Value.Type}' for '{resource.Name}.{input.Key}'. Only '{ParameterInputLiterals.String}' is supported.");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- update PopulateInputsAction to validate against `ParameterInputLiterals.String`
- add explicit import for literals

## Testing
- `dotnet test --no-build -v minimal` *(fails: The argument Aspirate.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686a4f28ce188331a4024e193211f7e6