### PR TITLE
Update Dapr TCP binding constant

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/ApplyDaprAnnotationsAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ApplyDaprAnnotationsAction.cs
@@ -1,3 +1,5 @@
+using Aspirate.Shared.Literals;
+
 namespace Aspirate.Commands.Actions.Manifests;
 
 public class ApplyDaprAnnotationsAction(IServiceProvider serviceProvider, IAnsiConsole console) : BaseAction(serviceProvider)
@@ -52,7 +54,7 @@ public class ApplyDaprAnnotationsAction(IServiceProvider serviceProvider, IAnsiC
             return;
         }
 
-        if (!container.Bindings.TryGetValue("tcp", out var binding))
+        if (!container.Bindings.TryGetValue(BindingLiterals.Tcp, out var binding))
         {
             return;
         }


### PR DESCRIPTION
## Summary
- use `BindingLiterals.Tcp` constant when determining Dapr port
- include missing `Aspirate.Shared.Literals` using directive

## Testing
- `dotnet restore`
- `dotnet build --no-restore` *(fails: BuildBuilder missing WithSecrets)*
- `dotnet test --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_686a505fd2508331906adc57ee5bfac9