### PR TITLE
Replace literal protocols with constants

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -1,3 +1,5 @@
+using Aspirate.Shared.Literals;
+
 namespace Aspirate.Commands.Actions.Manifests;
 
 public class ConfigureIngressAction(
@@ -28,7 +30,7 @@ public class ConfigureIngressAction(
 
         var candidates = CurrentState.AllSelectedSupportedComponents
             .Where(r => r.Value is IResourceWithBinding res && res.Bindings != null &&
-                        res.Bindings.Any(b => b.Key.Equals("http", StringComparison.OrdinalIgnoreCase) && b.Value.External))
+                        res.Bindings.Any(b => b.Key.Equals(BindingLiterals.Http, StringComparison.OrdinalIgnoreCase) && b.Value.External))
             .Select(r => r.Key)
             .ToList();
 

--- a/src/Aspirate.Services/Implementations/KubernetesService.cs
+++ b/src/Aspirate.Services/Implementations/KubernetesService.cs
@@ -1,3 +1,5 @@
+using Aspirate.Shared.Literals;
+
 namespace Aspirate.Services.Implementations;
 
 public class KubernetesService(IAnsiConsole logger, IKubeCtlService kubeCtlService, IServiceProvider serviceProvider)
@@ -448,5 +450,5 @@ public class KubernetesService(IAnsiConsole logger, IKubeCtlService kubeCtlServi
 
     private Func<V1ServicePort, bool> ExposableAsNodePort =>
         servicePort =>
-            servicePort.Name.Equals("http", StringComparison.OrdinalIgnoreCase) || servicePort.Port is 80 or 8080 or 18888;
+            servicePort.Name.Equals(BindingLiterals.Http, StringComparison.OrdinalIgnoreCase) || servicePort.Port is 80 or 8080 or 18888;
 }

--- a/src/Aspirate.Shared/Extensions/ResourceExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/ResourceExtensions.cs
@@ -1,6 +1,7 @@
 using Aspirate.Shared.Models.AspireManifests.Components.V1.Project;
 using Volume = Aspirate.Shared.Models.AspireManifests.Components.Common.Volume;
 using BindMount = Aspirate.Shared.Models.AspireManifests.Components.Common.BindMount;
+using Aspirate.Shared.Literals;
 
 namespace Aspirate.Shared.Extensions;
 
@@ -183,12 +184,12 @@ public static class ResourceExtensions
 
             foreach (var binding in bindingResource.Bindings)
             {
-                if (binding.Key.Equals("http", StringComparison.OrdinalIgnoreCase) && binding.Value.TargetPort is 0 or null)
+                if (binding.Key.Equals(BindingLiterals.Http, StringComparison.OrdinalIgnoreCase) && binding.Value.TargetPort is 0 or null)
                 {
                     binding.Value.TargetPort = 8080;
                 }
 
-                if (binding.Key.Equals("https", StringComparison.OrdinalIgnoreCase) && binding.Value.TargetPort is 0 or null)
+                if (binding.Key.Equals(BindingLiterals.Https, StringComparison.OrdinalIgnoreCase) && binding.Value.TargetPort is 0 or null)
                 {
                     binding.Value.TargetPort = 8443;
                 }


### PR DESCRIPTION
## Summary
- use `BindingLiterals.Http` and `BindingLiterals.Https` instead of string literals
- add references to literals' namespace

## Testing
- `dotnet test Aspirate.sln` *(fails: `BuildBuilder` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a516721488331b9f13ebe6eeaea86