### PR TITLE
Replace hardcoded filenames with TemplateLiterals

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/GenerateFinalKustomizeManifestAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/GenerateFinalKustomizeManifestAction.cs
@@ -47,13 +47,13 @@ public sealed class GenerateFinalKustomizeManifestAction(
         HandleDapr(CurrentState.OutputPath, manifests);
         HandleDashboard(CurrentState.IncludeDashboard, CurrentState.OutputPath, CurrentState.TemplatePath, templateDataBuilder, manifests);
 
-        Logger.MarkupLine("[bold]Generating final manifest with name [blue]'kustomization.yaml'[/][/]");
+        Logger.MarkupLine($"[bold]Generating final manifest with name [blue]'{TemplateLiterals.ComponentKustomizeType}.yaml'[/][/]");
 
         var templateData = templateDataBuilder.SetManifests(manifests);
 
         manifestWriter.CreateComponentKustomizeManifest(CurrentState.OutputPath, templateData, CurrentState.TemplatePath);
 
-        Logger.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Generating [blue]{CurrentState.OutputPath}/kustomization.yaml[/]");
+        Logger.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Generating [blue]{CurrentState.OutputPath}/{TemplateLiterals.ComponentKustomizeType}.yaml[/]");
 
         return Task.FromResult(true);
     }
@@ -78,7 +78,7 @@ public sealed class GenerateFinalKustomizeManifestAction(
         Logger.MarkupLine($"[bold]Generating namespace manifest with name [blue]'{@namespace}'[/][/]");
         manifestWriter.CreateNamespace(outputPath, templateDataBuilder, templatePath);
         manifests.Add($"{TemplateLiterals.NamespaceType}.yaml");
-        Logger.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Generating [blue]{outputPath}/namespace.yaml[/]");
+        Logger.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Generating [blue]{outputPath}/{TemplateLiterals.NamespaceType}.yaml[/]");
     }
 
     private void HandleDashboard(bool? withDashboard, string outputPath, string? templatePath, KubernetesDeploymentData templateDataBuilder, List<string> manifests)
@@ -93,7 +93,7 @@ public sealed class GenerateFinalKustomizeManifestAction(
         Logger.MarkupLine("[bold]Generating Aspire Dashboard manifest[/]");
         manifestWriter.CreateDashboard(outputPath, templateDataBuilder, templatePath);
         manifests.Add($"{TemplateLiterals.DashboardType}.yaml");
-        Logger.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Generating [blue]{outputPath}/dashboard.yaml[/]");
+        Logger.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Generating [blue]{outputPath}/{TemplateLiterals.DashboardType}.yaml[/]");
     }
 
     private void HandleDapr(string outputPath, List<string> manifests)

--- a/src/Aspirate.Services/Implementations/KubeCtlService.cs
+++ b/src/Aspirate.Services/Implementations/KubeCtlService.cs
@@ -194,7 +194,7 @@ public partial class KubeCtlService(IFileSystem filesystem, IAnsiConsole console
 
     private async Task<string> ParseNamespace(string fullOutputPath)
     {
-        var namespaceFile = filesystem.GetFullPath(Path.Combine(fullOutputPath, "namespace.yaml"));
+        var namespaceFile = filesystem.GetFullPath(Path.Combine(fullOutputPath, $"{TemplateLiterals.NamespaceType}.yaml"));
 
         if (!filesystem.File.Exists(namespaceFile))
         {


### PR DESCRIPTION
## Summary
- use TemplateLiterals.ComponentKustomizeType when logging file names
- use TemplateLiterals.NamespaceType when logging namespace path and parsing
- use TemplateLiterals.DashboardType when logging dashboard path

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --verbosity minimal` *(fails: BuildBuilder missing WithSecrets)*

------
https://chatgpt.com/codex/tasks/task_e_686a52d50e608331b56b76b3e39bc49f