### PR TITLE
Fix image pull secret constant

### DIFF
--- a/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
@@ -379,7 +379,7 @@ public static class KubernetesDeploymentDataExtensions
 
     private static List<V1LocalObjectReference> SetKubernetesImagePullSecrets =>
     [
-        new V1LocalObjectReference { Name = "image-pull-secret", }
+        new V1LocalObjectReference { Name = TemplateLiterals.ImagePullSecretType, }
     ];
 
     private static void SetContainerEnvironment(KubernetesDeploymentData data, bool useConfigMap, bool useSecrets, V1Container container)


### PR DESCRIPTION
## Summary
- reference `TemplateLiterals.ImagePullSecretType` when creating image pull secret references

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build --verbosity minimal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686a544f08ec8331b8e21470501d84b4