### PR TITLE
Use deployment constant in Aspire models

### DIFF
--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V1/Container/ContainerV1Resource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V1/Container/ContainerV1Resource.cs
@@ -1,3 +1,5 @@
+using Aspirate.Shared.Literals;
+
 namespace Aspirate.Shared.Models.AspireManifests.Components.V1.Container;
 
 public class ContainerV1Resource : ContainerResourceBase
@@ -8,7 +10,7 @@ public class ContainerV1Resource : ContainerResourceBase
     [JsonPropertyName("build")]
     public Build? Build { get; set; }
 
-    [JsonPropertyName("deployment")]
+    [JsonPropertyName(TemplateLiterals.DeploymentType)]
     [JsonConverter(typeof(BicepResourceConverter))]
     public BicepResource? Deployment { get; set; }
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V1/Project/ProjectV1Resource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V1/Project/ProjectV1Resource.cs
@@ -1,11 +1,12 @@
 using System.Text.Json.Serialization;
+using Aspirate.Shared.Literals;
 using Aspirate.Shared.Models.AspireManifests.Components.Azure;
 
 namespace Aspirate.Shared.Models.AspireManifests.Components.V1.Project;
 
 public class ProjectV1Resource : ProjectResource
 {
-    [JsonPropertyName("deployment")]
+    [JsonPropertyName(TemplateLiterals.DeploymentType)]
     [JsonConverter(typeof(BicepResourceConverter))]
     public BicepResource? Deployment { get; set; }
 }


### PR DESCRIPTION
## Summary
- ensure `TemplateLiterals.DeploymentType` constant is used
- replace hard-coded JsonPropertyName values in container and project model classes

## Testing
- `dotnet build` *(fails: BuildBuilder does not contain WithSecrets)*

------
https://chatgpt.com/codex/tasks/task_e_686a571224a08331983ac34441973b95