### PR TITLE
Use transformation literals in tests

### DIFF
--- a/tests/Aspirate.Tests/ModelTests/DaprComponentSerializationTests.cs
+++ b/tests/Aspirate.Tests/ModelTests/DaprComponentSerializationTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Xunit;
+using Aspirate.Processors.Transformation;
 
 namespace Aspirate.Tests.ModelTests;
 
@@ -23,7 +24,7 @@ public class DaprComponentSerializationTests
 
         resource.DaprComponentProperty!.Type.Should().Be("state.redis");
         resource.DaprComponentProperty.Version.Should().Be("v1");
-        resource.DaprComponentProperty.Metadata.Should().ContainKey("connectionString");
+        resource.DaprComponentProperty.Metadata.Should().ContainKey(Literals.ConnectionString);
 
         var serialized = JsonSerializer.Serialize(resource);
 
@@ -32,7 +33,7 @@ public class DaprComponentSerializationTests
 
         var roundTrip = JsonSerializer.Deserialize<DaprComponentResource>(serialized)!;
         roundTrip.DaprComponentProperty!.Version.Should().Be("v1");
-        roundTrip.DaprComponentProperty.Metadata.Should().ContainKey("connectionString");
+        roundTrip.DaprComponentProperty.Metadata.Should().ContainKey(Literals.ConnectionString);
     }
 }
 

--- a/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
+++ b/tests/Aspirate.Tests/ProcessorTests/RequiredPropertyValidationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.Json.Nodes;
 using Aspirate.Processors.Transformation.Bindings;
+using Aspirate.Processors.Transformation;
 using Xunit;
 using Aspirate.Processors.Resources.Project;
 
@@ -142,7 +143,7 @@ public class RequiredPropertyValidationTests
         var json = "{\"pg\":{\"image\":\"img\",\"bindings\":{\"tcp\":{\"scheme\":\"tcp\",\"protocol\":\"tcp\"}}}}";
         var node = JsonNode.Parse(json);
 
-        var act = () => bindingProcessor.ParseBinding(["pg", "bindings", "tcp", "port"], node);
+        var act = () => bindingProcessor.ParseBinding(["pg", Literals.Bindings, "tcp", Literals.Port], node);
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("Transport is required for a binding.");

--- a/tests/Aspirate.Tests/SecretTests/SecretProviderFactoryTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretProviderFactoryTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using System.IO.Abstractions;
+using Aspirate.Processors.Transformation;
 using Xunit;
 
 namespace Aspirate.Tests.SecretTests;
@@ -30,7 +31,7 @@ public class SecretProviderFactoryTests
     public void GetProvider_Env_ReturnsEnvironmentProvider()
     {
         var factory = CreateServices().GetRequiredService<SecretProviderFactory>();
-        var provider = factory.GetProvider("env");
+        var provider = factory.GetProvider(Literals.Env);
         Assert.IsType<EnvironmentSecretProvider>(provider);
     }
 


### PR DESCRIPTION
## Summary
- use `Aspirate.Processors.Transformation.Literals` in tests

## Testing
- `dotnet test Aspirate.sln -c Release -nologo` *(fails: BuildBuilder missing method)*

------
https://chatgpt.com/codex/tasks/task_e_686a585f81888331b2a06dfcd648521f