### PR TITLE
Update secret manager literals

### DIFF
--- a/src/Aspirate.Commands/Options/SecretProviderOption.cs
+++ b/src/Aspirate.Commands/Options/SecretProviderOption.cs
@@ -4,7 +4,10 @@ public sealed class SecretProviderOption : BaseOption<string?>
 {
     private static readonly string[] _aliases = ["--secret-provider"];
 
-    private SecretProviderOption() : base(_aliases, "ASPIRATE_SECRET_PROVIDER", "file")
+    private SecretProviderOption() : base(
+        _aliases,
+        "ASPIRATE_SECRET_PROVIDER",
+        Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager)
     {
         Name = nameof(ICommandOptions.SecretProvider);
         Description = "The secret backend provider to use. Defaults to file.";

--- a/src/Aspirate.Secrets/SecretProviderFactory.cs
+++ b/src/Aspirate.Secrets/SecretProviderFactory.cs
@@ -9,9 +9,12 @@ public class SecretProviderFactory(IServiceProvider services)
     {
         return (provider?.ToLowerInvariant()) switch
         {
-            null or "" or "file" or "password" => services.GetRequiredService<SecretProvider>(),
-            "env" or "environment" => services.GetRequiredService<EnvironmentSecretProvider>(),
-            "base64" => services.GetRequiredService<Base64SecretProvider>(),
+            null or "" or Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager or Aspirate.Shared.Literals.AspirateSecretLiterals.PasswordSecretsManager =>
+                services.GetRequiredService<SecretProvider>(),
+            Aspirate.Shared.Literals.AspirateSecretLiterals.EnvironmentSecretsManager or Aspirate.Shared.Literals.AspirateSecretLiterals.EnvironmentSecretsManagerLong =>
+                services.GetRequiredService<EnvironmentSecretProvider>(),
+            Aspirate.Shared.Literals.AspirateSecretLiterals.Base64SecretsManager =>
+                services.GetRequiredService<Base64SecretProvider>(),
             _ => throw new InvalidOperationException($"Unknown secret provider '{provider}'.")
         };
     }

--- a/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
+++ b/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
@@ -24,7 +24,7 @@ public class ManifestFileParserService(
             "type",
             "path",
             "context",
-            "env",
+            Aspirate.Processors.Transformation.Literals.Env,
             "bindings",
             "buildArgs"
         ]),
@@ -35,7 +35,7 @@ public class ManifestFileParserService(
             "entrypoint",
             "args",
             "connectionString",
-            "env",
+            Aspirate.Processors.Transformation.Literals.Env,
             "bindings",
             "bindMounts",
             "volumes"
@@ -49,7 +49,7 @@ public class ManifestFileParserService(
             "args",
             "build",
             "connectionString",
-            "env",
+            Aspirate.Processors.Transformation.Literals.Env,
             "bindings",
             "bindMounts",
             "volumes"
@@ -59,7 +59,7 @@ public class ManifestFileParserService(
             "type",
             "path",
             "args",
-            "env",
+            Aspirate.Processors.Transformation.Literals.Env,
             "bindings"
         ]),
         [AspireComponentLiterals.ProjectV1] = new(
@@ -68,7 +68,7 @@ public class ManifestFileParserService(
             "path",
             "deployment",
             "args",
-            "env",
+            Aspirate.Processors.Transformation.Literals.Env,
             "bindings"
         ]),
         [AspireComponentLiterals.Executable] = new(
@@ -77,7 +77,7 @@ public class ManifestFileParserService(
             "command",
             "workingDirectory",
             "args",
-            "env",
+            Aspirate.Processors.Transformation.Literals.Env,
             "bindings"
         ]),
         [AspireComponentLiterals.Value] = new(

--- a/src/Aspirate.Shared/Literals/AspirateSecretLiterals.cs
+++ b/src/Aspirate.Shared/Literals/AspirateSecretLiterals.cs
@@ -2,6 +2,28 @@ namespace Aspirate.Shared.Literals;
 
 public static class AspirateSecretLiterals
 {
-    public const string Base64SecretsManager = "base64";
+    /// <summary>
+    /// Identifier used for the default file backed secrets manager.
+    /// </summary>
+    public const string FileSecretsManager = "file";
+
+    /// <summary>
+    /// Identifier used for secrets stored as environment variables.
+    /// </summary>
+    public const string EnvironmentSecretsManager = "env";
+
+    /// <summary>
+    /// Alternative identifier used for environment variable secrets manager.
+    /// </summary>
+    public const string EnvironmentSecretsManagerLong = "environment";
+
+    /// <summary>
+    /// Identifier used for the password protected secrets manager.
+    /// </summary>
     public const string PasswordSecretsManager = "password";
+
+    /// <summary>
+    /// Identifier used for the base64 encoded secrets manager.
+    /// </summary>
+    public const string Base64SecretsManager = "base64";
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BuildSecret.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/BuildSecret.cs
@@ -5,10 +5,10 @@ namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 
 public enum BuildSecretType
 {
-    [EnumMember(Value = "env")]
+    [EnumMember(Value = Aspirate.Shared.Literals.AspirateSecretLiterals.EnvironmentSecretsManager)]
     Env,
 
-    [EnumMember(Value = "file")]
+    [EnumMember(Value = Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager)]
     File,
 }
 

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Container/ContainerResourceBase.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/Container/ContainerResourceBase.cs
@@ -22,7 +22,7 @@ public class ContainerResourceBase : Resource,
     [JsonPropertyName("annotations")]
     public Dictionary<string, string>? Annotations { get; set; } = [];
 
-    [JsonPropertyName("env")]
+    [JsonPropertyName(Aspirate.Processors.Transformation.Literals.Env)]
     public Dictionary<string, string>? Env { get; set; } = [];
 
     [JsonPropertyName("volumes")]

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/ProjectResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/ProjectResource.cs
@@ -21,7 +21,7 @@ public class ProjectResource : Resource, IResourceWithBinding, IResourceWithAnno
     [JsonPropertyName("annotations")]
     public Dictionary<string, string>? Annotations { get; set; } = [];
 
-    [JsonPropertyName("env")]
+    [JsonPropertyName(Aspirate.Processors.Transformation.Literals.Env)]
     public Dictionary<string, string>? Env { get; set; } = [];
 
     [JsonPropertyName("args")]

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/DockerfileResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/DockerfileResource.cs
@@ -24,7 +24,7 @@ public class DockerfileResource : Resource, IResourceWithBinding, IResourceWithE
     [JsonPropertyName("bindings")]
     public Dictionary<string, Binding>? Bindings { get; set; }
 
-    [JsonPropertyName("env")]
+    [JsonPropertyName(Aspirate.Processors.Transformation.Literals.Env)]
     public Dictionary<string, string>? Env { get; set; }
 
     [JsonPropertyName("buildArgs")]

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/ExecutableResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/ExecutableResource.cs
@@ -12,7 +12,7 @@ public class ExecutableResource : Resource,
     [JsonPropertyName("workingDirectory")]
     public string? WorkingDirectory { get; set; }
 
-    [JsonPropertyName("env")]
+    [JsonPropertyName(Aspirate.Processors.Transformation.Literals.Env)]
     public Dictionary<string, string>? Env { get; set; } = [];
 
     [JsonPropertyName("bindings")]

--- a/src/Aspirate.Shared/Models/Compose/ComposeBuildSecret.cs
+++ b/src/Aspirate.Shared/Models/Compose/ComposeBuildSecret.cs
@@ -4,9 +4,9 @@ namespace Aspirate.Shared.Models.Compose;
 
 public class ComposeBuildSecret
 {
-    [YamlMember(Alias = "environment")]
+    [YamlMember(Alias = Aspirate.Shared.Literals.AspirateSecretLiterals.EnvironmentSecretsManagerLong)]
     public string? Environment { get; set; }
 
-    [YamlMember(Alias = "file")]
+    [YamlMember(Alias = Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager)]
     public string? File { get; set; }
 }

--- a/tests/Aspirate.Tests/AspirateTestBase.cs
+++ b/tests/Aspirate.Tests/AspirateTestBase.cs
@@ -36,7 +36,7 @@ public abstract class AspirateTestBase
             InputPath = inputPath,
             KubeContext = kubeContext,
             SecretPassword = password,
-            SecretProvider = "file",
+            SecretProvider = Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager,
             OutputFormat = outputFormat,
         };
 

--- a/tests/Aspirate.Tests/CommandTests/ListSecretsCommandHandlerTests.cs
+++ b/tests/Aspirate.Tests/CommandTests/ListSecretsCommandHandlerTests.cs
@@ -41,7 +41,7 @@ public class ListSecretsCommandHandlerTests : AspirateTestBase
             NonInteractive = true,
             DisableSecrets = false,
             SecretPassword = state.SecretPassword,
-            SecretProvider = "file",
+            SecretProvider = Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager,
             CommandUnlocksSecrets = true,
         });
 
@@ -76,7 +76,7 @@ public class ListSecretsCommandHandlerTests : AspirateTestBase
             NonInteractive = true,
             DisableSecrets = false,
             SecretPassword = state.SecretPassword,
-            SecretProvider = "file",
+            SecretProvider = Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager,
             CommandUnlocksSecrets = true,
         });
 

--- a/tests/Aspirate.Tests/SecretTests/SecretProviderFactoryTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/SecretProviderFactoryTests.cs
@@ -23,7 +23,7 @@ public class SecretProviderFactoryTests
     public void GetProvider_File_ReturnsFileProvider()
     {
         var factory = CreateServices().GetRequiredService<SecretProviderFactory>();
-        var provider = factory.GetProvider("file");
+        var provider = factory.GetProvider(Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager);
         Assert.IsType<SecretProvider>(provider);
     }
 
@@ -39,7 +39,7 @@ public class SecretProviderFactoryTests
     public void GetProvider_Base64_ReturnsBase64Provider()
     {
         var factory = CreateServices().GetRequiredService<SecretProviderFactory>();
-        var provider = factory.GetProvider("base64");
+        var provider = factory.GetProvider(Aspirate.Shared.Literals.AspirateSecretLiterals.Base64SecretsManager);
         Assert.IsType<Base64SecretProvider>(provider);
     }
 

--- a/tests/Aspirate.Tests/ServiceTests/SecretServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/SecretServiceTests.cs
@@ -277,7 +277,7 @@ public class SecretServiceTests : BaseServiceTests<ISecretService>
             NonInteractive = true,
             DisableSecrets = false,
             SecretPassword = string.Empty,
-            SecretProvider = "file",
+            SecretProvider = Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager,
             StatePath = statePath,
             Force = true
         });
@@ -310,7 +310,7 @@ public class SecretServiceTests : BaseServiceTests<ISecretService>
             NonInteractive = true,
             DisableSecrets = false,
             SecretPassword = string.Empty,
-            SecretProvider = "file",
+            SecretProvider = Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager,
             StatePath = statePath
         });
 
@@ -513,7 +513,7 @@ public class SecretServiceTests : BaseServiceTests<ISecretService>
             NonInteractive = true,
             DisableSecrets = false,
             SecretPassword = string.Empty,
-            SecretProvider = "file",
+            SecretProvider = Aspirate.Shared.Literals.AspirateSecretLiterals.FileSecretsManager,
             StatePath = statePath,
             Force = true
         });


### PR DESCRIPTION
## Summary
- centralize secret manager names in `AspirateSecretLiterals`
- reference new constants across services, models and tests

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5b714e848331b9aef8a14694e1a1