### PR TITLE
Add DashboardName constant

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/GenerateDockerComposeManifestAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/GenerateDockerComposeManifestAction.cs
@@ -142,10 +142,10 @@ public sealed class GenerateDockerComposeManifestAction(IServiceProvider service
             new() { Published = 18888, Target = 18888 }
         };
 
-        var aspireDashboard = Builder.MakeService("aspire-dashboard")
+        var aspireDashboard = Builder.MakeService(AspireLiterals.DashboardName)
             .WithImage(AspireLiterals.DashboardImage)
             .WithEnvironment(environment)
-            .WithContainerName("aspire-dashboard")
+            .WithContainerName(AspireLiterals.DashboardName)
             .WithRestartPolicy(ERestartMode.UnlessStopped)
             .WithPortMappings(ports.ToArray())
             .Build();

--- a/src/Aspirate.Services/Implementations/KubernetesService.cs
+++ b/src/Aspirate.Services/Implementations/KubernetesService.cs
@@ -284,7 +284,7 @@ public class KubernetesService(IAnsiConsole logger, IKubeCtlService kubeCtlServi
     {
         var labels = new Dictionary<string, string>
         {
-            ["app"] = "aspire-dashboard",
+            ["app"] = AspireLiterals.DashboardName,
         };
 
         var deployment = AspireDashboard.GetDeployment(labels);

--- a/src/Aspirate.Shared/Extensions/ResourceExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/ResourceExtensions.cs
@@ -37,7 +37,7 @@ public static class ResourceExtensions
 
         if (withDashboard == true)
         {
-            environment.TryAdd("OTEL_EXPORTER_OTLP_ENDPOINT", "http://aspire-dashboard:18889");
+            environment.TryAdd("OTEL_EXPORTER_OTLP_ENDPOINT", $"http://{AspireLiterals.DashboardName}:18889");
             environment.TryAdd("OTEL_SERVICE_NAME", resource.Key);
         }
 

--- a/src/Aspirate.Shared/Literals/AspireLiterals.cs
+++ b/src/Aspirate.Shared/Literals/AspireLiterals.cs
@@ -8,5 +8,7 @@ public static class AspireLiterals
 
     public const string ManifestPublisherArgument = "manifest";
 
+    public const string DashboardName = "aspire-dashboard";
+
     public const string DashboardImage = "mcr.microsoft.com/dotnet/aspire-dashboard:9.0";
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/AspireDashboard.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/AspireDashboard.cs
@@ -7,7 +7,7 @@ public static class AspireDashboard
         {
             ApiVersion = "apps/v1",
             Kind = "Deployment",
-            Metadata = new V1ObjectMeta { Name = "aspire-dashboard", Labels = labels, },
+            Metadata = new V1ObjectMeta { Name = AspireLiterals.DashboardName, Labels = labels, },
             Spec = new V1DeploymentSpec
             {
                 Replicas = 1,
@@ -24,7 +24,7 @@ public static class AspireDashboard
                         {
                             new()
                             {
-                                Name = "aspire-dashboard",
+                                Name = AspireLiterals.DashboardName,
                                 Image = AspireLiterals.DashboardImage,
                                 Resources =
                                     new V1ResourceRequirements
@@ -58,7 +58,7 @@ public static class AspireDashboard
         {
             ApiVersion = "v1",
             Kind = "Service",
-            Metadata = new V1ObjectMeta { Name = "aspire-dashboard" },
+            Metadata = new V1ObjectMeta { Name = AspireLiterals.DashboardName },
             Spec = new V1ServiceSpec
             {
                 Selector = labels,


### PR DESCRIPTION
## Summary
- add DashboardName constant to AspireLiterals
- use DashboardName constant in Docker compose generation
- use DashboardName constant for AspireDashboard resources
- use DashboardName constant in KubernetesService
- reference DashboardName when adding OTLP endpoint

## Testing
- `dotnet test` *(fails: type or namespace name 'Shared' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_686a5db86ad4833198687ec0323a525f