### PR TITLE
Fix ingress candidate detection

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -31,13 +31,13 @@ public class ConfigureIngressAction(
         var candidates = CurrentState.AllSelectedSupportedComponents
             .Where(r => r.Value is IResourceWithBinding res &&
                         res.Bindings != null &&
-                        res.Bindings.ContainsKey(BindingLiterals.Http))
+                        res.Bindings.Values.Any(b => b.External))
             .Select(r => r.Key)
             .ToList();
 
         if (candidates.Count == 0)
         {
-            Logger.MarkupLine("[yellow](!)[/] No HTTP services detected.");
+            Logger.MarkupLine("[yellow](!)[/] No services with external bindings detected.");
             return true;
         }
 


### PR DESCRIPTION
## Summary
- update candidate selection logic so that ingress can find all services with HTTP bindings

## Testing
- `dotnet build tests/Aspirate.Tests/Aspirate.Tests.csproj -c Release` *(fails: type or namespace name 'Shared' does not exist in the namespace 'Aspirate.Shared.Models.Aspirate')*

------
https://chatgpt.com/codex/tasks/task_e_686e27f5af688331a33989b4e2c7b78f