### PR TITLE
Add ingress manifest generation

### DIFF
--- a/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
@@ -112,6 +112,12 @@ public abstract class BaseContainerProcessor<TContainerResource>(
         var image = GetImageFromContainerResource(options.Resource);
         var data = PopulateKubernetesDeploymentData(options, image, container, manifests);
 
+        if (data.IngressEnabled == true)
+        {
+            manifests.Add($"{TemplateLiterals.IngressType}.yaml");
+            data.SetManifests(manifests);
+        }
+
         if (container.Volumes.Count > 0)
         {
             _manifestWriter.CreateStatefulSet(resourceOutputPath, data, options.TemplatePath);
@@ -122,6 +128,10 @@ public abstract class BaseContainerProcessor<TContainerResource>(
         }
 
         _manifestWriter.CreateService(resourceOutputPath, data, options.TemplatePath);
+        if (data.IngressEnabled == true)
+        {
+            _manifestWriter.CreateIngress(resourceOutputPath, data);
+        }
         _manifestWriter.CreateComponentKustomizeManifest(resourceOutputPath, data, options.TemplatePath);
 
         LogCompletion(resourceOutputPath);

--- a/src/Aspirate.Processors/Resources/Project/BaseProjectProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Project/BaseProjectProcessor.cs
@@ -56,8 +56,19 @@ public abstract class BaseProjectProcessor(
 
         var data = PopulateKubernetesDeploymentData(options, containerDetails, project);
 
+        var manifests = _manifests.ToList();
+        if (data.IngressEnabled == true)
+        {
+            manifests.Add($"{TemplateLiterals.IngressType}.yaml");
+            data.SetManifests(manifests);
+        }
+
         _manifestWriter.CreateDeployment(resourceOutputPath, data, options.TemplatePath);
         _manifestWriter.CreateService(resourceOutputPath, data, options.TemplatePath);
+        if (data.IngressEnabled == true)
+        {
+            _manifestWriter.CreateIngress(resourceOutputPath, data);
+        }
         _manifestWriter.CreateComponentKustomizeManifest(resourceOutputPath, data, options.TemplatePath);
 
         LogCompletion(resourceOutputPath);

--- a/src/Aspirate.Services/Implementations/ManifestWriter.cs
+++ b/src/Aspirate.Services/Implementations/ManifestWriter.cs
@@ -76,6 +76,20 @@ public class ManifestWriter(IFileSystem fileSystem) : IManifestWriter
     }
 
     /// <inheritdoc />
+    public void CreateIngress<TTemplateData>(string outputPath, TTemplateData data)
+    {
+        if (data is not KubernetesDeploymentData deploymentData)
+        {
+            throw new InvalidOperationException("Ingress generation requires KubernetesDeploymentData");
+        }
+
+        var ingress = deploymentData.ToKubernetesIngress();
+        var yaml = KubernetesYaml.Serialize(ingress);
+
+        fileSystem.File.WriteAllText(Path.Combine(outputPath, $"{TemplateLiterals.IngressType}.yaml"), yaml);
+    }
+
+    /// <inheritdoc />
     public void CreateComponentKustomizeManifest<TTemplateData>(
         string outputPath,
         TTemplateData data,

--- a/src/Aspirate.Shared/Interfaces/Services/IManifestWriter.cs
+++ b/src/Aspirate.Shared/Interfaces/Services/IManifestWriter.cs
@@ -53,6 +53,13 @@ public interface IManifestWriter
     void CreateService<TTemplateData>(string outputPath, TTemplateData data, string? templatePath);
 
     /// <summary>
+    /// Creates an ingress manifest for the specified deployment data.
+    /// </summary>
+    /// <param name="outputPath">The path where the ingress manifest will be created.</param>
+    /// <param name="data">The deployment data containing ingress settings.</param>
+    void CreateIngress<TTemplateData>(string outputPath, TTemplateData data);
+
+    /// <summary>
     /// Creates a Kustomize manifest for a component.
     /// </summary>
     /// <param name="outputPath">The directory where the manifest file will be created.</param>

--- a/src/Aspirate.Shared/Literals/TemplateLiterals.cs
+++ b/src/Aspirate.Shared/Literals/TemplateLiterals.cs
@@ -8,6 +8,7 @@ public static class TemplateLiterals
     public const string StatefulSetType = "statefulset";
     public const string DaprComponentType = "dapr-component";
     public const string ServiceType = "service";
+    public const string IngressType = "ingress";
     public const string ComponentKustomizeType = "kustomization";
     public const string NamespaceType = "namespace";
     public const string DashboardType = "dashboard";


### PR DESCRIPTION
## Summary
- generate Kubernetes ingress YAML when ingress is enabled
- expose ingress template name constant
- allow manifest writer to produce ingress files

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: ActionCausesExitException, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686e3177a7848331994a85d2bc16bde2