### PR TITLE
Fix ingress option for kustomize generation

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/GenerateKustomizeManifestsAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/GenerateKustomizeManifestsAction.cs
@@ -61,7 +61,8 @@ public sealed class GenerateKustomizeManifestsAction(
             TemplatePath = CurrentState.TemplatePath,
             DisableSecrets =  CurrentState.DisableSecrets,
             WithPrivateRegistry = CurrentState.WithPrivateRegistry,
-            WithDashboard = CurrentState.IncludeDashboard
+            WithDashboard = CurrentState.IncludeDashboard,
+            CurrentState = CurrentState
         });
 
         if (success && !CurrentState.IsNotDeployable(resource.Value) && resource.Value is not DaprComponentResource)


### PR DESCRIPTION
## Summary
- pass `AspirateState` into manifest generation so ingress definitions are applied

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686e369ea0c88331a14255b66e1e081e