### PR TITLE
Fix ingress reuse

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -10,6 +10,11 @@ public class ConfigureIngressAction(
     {
         Logger.WriteRuler("[purple]Configuring Ingress[/]");
 
+        if (PreviousStateWasRestored())
+        {
+            return true;
+        }
+
         if (CurrentState.WithIngress == null)
         {
             if (CurrentState.NonInteractive)


### PR DESCRIPTION
## Summary
- skip re-prompting for ingress settings when state was restored

## Testing
- `dotnet build Aspirate.sln --no-restore`
- `dotnet test Aspirate.sln` *(fails: 64 failed)*

------
https://chatgpt.com/codex/tasks/task_e_686e42a819908331be6982f34de8df60