### PR TITLE
Only ask annotations for external services

### DIFF
--- a/docs/Writerside/topics/Generate-Command.md
+++ b/docs/Writerside/topics/Generate-Command.md
@@ -61,7 +61,7 @@ AWS CloudFormation templates can be referenced in your manifest using `aws.cloud
 
 `aspirate` accepts additional fields beyond the official .NET Aspire schema. These extra fields are treated as extensions and are preserved when reading and writing manifest files.
 
-When running interactively, `aspirate` will prompt for annotations for any selected resources. The supplied values are persisted in the state file so they can be reused on subsequent runs. Annotations are configured separately and are **not** read from `manifest.json`.
+When running interactively with ingress enabled, `aspirate` prompts for annotations for each selected external service alongside the host and TLS secret questions. The supplied values are persisted in the state file so they can be reused on subsequent runs. Annotations are configured separately and are **not** read from `manifest.json`.
 
 ##Specify components when running with `--non-interactive`
 When ran non-interactively, you can specify which components to build with `-c` or `--components`. Example: `-c webApi -c frontend -c sql -c redis`.

--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -32,6 +32,7 @@ public class ConfigureIngressAction(
         }
 
         CurrentState.IngressDefinitions ??= new();
+        CurrentState.ResourceAnnotations ??= new();
 
         var candidates = CurrentState.AllSelectedSupportedComponents
             .Where(r => r.Value is IResourceWithBinding res &&
@@ -65,6 +66,30 @@ public class ConfigureIngressAction(
                     new TextPrompt<string>($"[bold]Enter TLS secret for service [blue]{service}[/] (leave blank if none): [/]")
                         .PromptStyle("yellow")
                         .AllowEmpty());
+
+                var annotations = new Dictionary<string, string>();
+                while (true)
+                {
+                    var key = Logger.Prompt(new TextPrompt<string>($"Enter annotation key for [blue]{service}[/] (leave blank to stop): ")
+                        .PromptStyle("yellow")
+                        .AllowEmpty());
+
+                    if (string.IsNullOrWhiteSpace(key))
+                    {
+                        break;
+                    }
+
+                    var value = Logger.Prompt(new TextPrompt<string>($"Enter value for annotation [blue]{key}[/]: ")
+                        .PromptStyle("yellow"));
+
+                    annotations[key] = value;
+                }
+
+                if (annotations.Count > 0)
+                {
+                    CurrentState.ResourceAnnotations[service] = annotations;
+                }
+
                 CurrentState.IngressDefinitions[service] = new IngressDefinition
                 {
                     Host = host,

--- a/src/Aspirate.Commands/Commands/Generate/GenerateCommandHandler.cs
+++ b/src/Aspirate.Commands/Commands/Generate/GenerateCommandHandler.cs
@@ -27,7 +27,6 @@ public sealed class GenerateCommandHandler(IServiceProvider serviceProvider) : B
             .QueueAction(nameof(PopulateInputsAction))
             .QueueAction(nameof(SubstituteValuesAspireManifestAction))
             .QueueAction(nameof(ApplyDaprAnnotationsAction))
-            .QueueAction(nameof(ConfigureAnnotationsAction))
             .QueueAction(nameof(PopulateContainerDetailsForProjectsAction))
             .QueueAction(nameof(BuildAndPushContainersFromProjectsAction))
             .QueueAction(nameof(BuildAndPushContainersFromDockerfilesAction))

--- a/src/Aspirate.Commands/Commands/Run/RunCommandHandler.cs
+++ b/src/Aspirate.Commands/Commands/Run/RunCommandHandler.cs
@@ -11,7 +11,6 @@ public sealed class RunCommandHandler(IServiceProvider serviceProvider) : BaseCo
             .QueueAction(nameof(PopulateInputsAction))
             .QueueAction(nameof(SubstituteValuesAspireManifestAction))
             .QueueAction(nameof(ApplyDaprAnnotationsAction))
-            .QueueAction(nameof(ConfigureAnnotationsAction))
             .QueueAction(nameof(PopulateContainerDetailsForProjectsAction))
             .QueueAction(nameof(BuildAndPushContainersFromProjectsAction))
             .QueueAction(nameof(BuildAndPushContainersFromDockerfilesAction))

--- a/src/Aspirate.Commands/ServiceCollectionExtensions.cs
+++ b/src/Aspirate.Commands/ServiceCollectionExtensions.cs
@@ -38,7 +38,6 @@ public static class ServiceCollectionExtensions
             .RegisterAction<RemoveManifestsFromClusterAction>()
             .RegisterAction<SubstituteValuesAspireManifestAction>()
             .RegisterAction<ApplyDaprAnnotationsAction>()
-            .RegisterAction<ConfigureAnnotationsAction>()
             .RegisterAction<PopulateInputsAction>()
             .RegisterAction<SaveSecretsAction>()
             .RegisterAction<AskPrivateRegistryCredentialsAction>()


### PR DESCRIPTION
## Summary
- capture annotations when configuring ingress
- remove standalone annotations action
- update action registration
- document updated prompting behavior

## Testing
- `dotnet build --no-restore`
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build --verbosity minimal` *(fails: The argument Aspirate.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686f31b3a920833197d2099cd8b51bd7