### PR TITLE
Fix double password prompt

### DIFF
--- a/src/Aspirate.Commands/Commands/VerifySecrets/VerifySecretsCommand.cs
+++ b/src/Aspirate.Commands/Commands/VerifySecrets/VerifySecretsCommand.cs
@@ -2,7 +2,8 @@ namespace Aspirate.Commands.Commands.VerifySecrets;
 
 public sealed class VerifySecretsCommand : BaseCommand<VerifySecretsOptions, VerifySecretsCommandHandler>
 {
-    protected override bool CommandUnlocksSecrets => true;
+    // Avoid unlocking secrets in BaseCommand to prevent duplicate password prompts.
+    protected override bool CommandUnlocksSecrets => false;
     protected override bool CommandAlwaysRequiresState => true;
 
     public VerifySecretsCommand() : base("verify-secrets", "Verifies the password protecting secrets")


### PR DESCRIPTION
## Summary
- avoid unlocking secrets before executing verify command

## Testing
- `dotnet test` *(fails: NullReferenceException in ContainerCompositionServiceTest)*

------
https://chatgpt.com/codex/tasks/task_e_686f3f25ac5c8331b87eb1e5f4d7e693