### PR TITLE
Fix service port mapping and tests

### DIFF
--- a/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
@@ -274,8 +274,8 @@ public static class KubernetesDeploymentDataExtensions
                 Selector = labels,
                 Ports = data.Ports.Select(x => new V1ServicePort
                 {
-                    Port = x.InternalPort,
-                    TargetPort = x.ExternalPort,
+                    Port = x.ExternalPort,
+                    TargetPort = x.InternalPort,
                     Name = x.Name
                 }).ToList(),
                 Type = data.ServiceType,

--- a/tests/Aspirate.Tests/ExtensionTests/KubernetesDeploymentDataExtensionTests.cs
+++ b/tests/Aspirate.Tests/ExtensionTests/KubernetesDeploymentDataExtensionTests.cs
@@ -116,6 +116,24 @@ public class KubernetesDeploymentDataExtensionTests
         // Assert
         result.Spec.Ports[0].Name.Should().Be("test-port");
         result.Spec.Ports[0].Port.Should().Be(8080);
+        result.Spec.Ports[0].TargetPort.Value.Should().Be(8080);
+    }
+
+    [Fact]
+    public void ToKubernetesService_DifferentPorts_ShouldMapExternalAndInternal()
+    {
+        // Arrange
+        var data = new KubernetesDeploymentData()
+            .SetName("test")
+            .SetPorts(new List<Ports> { new Ports { Name = "test-port", InternalPort = 8080, ExternalPort = 80 } });
+
+        // Act
+        var result = data.ToKubernetesService();
+
+        // Assert
+        result.Spec.Ports[0].Name.Should().Be("test-port");
+        result.Spec.Ports[0].Port.Should().Be(80);
+        result.Spec.Ports[0].TargetPort.Value.Should().Be(8080);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- map external and internal ports correctly when creating Kubernetes services
- validate port mapping in KubernetesDeploymentDataExtensionTests

## Testing
- `dotnet test --no-build` *(fails: The argument Aspairate.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686f45e2a60c8331b8e0b7fb0b0bb636