### PR TITLE
Add ingress port selection

### DIFF
--- a/docs/Writerside/topics/Ingress-Support.md
+++ b/docs/Writerside/topics/Ingress-Support.md
@@ -2,7 +2,7 @@
 
 Aspir8 can optionally generate Kubernetes Ingress resources for services that expose HTTP bindings.
 During `generate` or `run` you will be prompted to select the services you wish to expose. For each
-service you can provide a host name and optional TLS secret. Selected values are stored in the
+service you can provide a host name, optional service port, and optional TLS secret. Selected values are stored in the
 project state so subsequent runs reuse them.
 
 When enabled, Aspir8 will also offer to deploy the NGINX ingress controller if it is not found
@@ -21,3 +21,5 @@ aspirate run --with-ingress
 | Option | Environmental Variable | Description |
 |-------|-----------------------|-------------|
 | --with-ingress | `ASPIRATE_WITH_INGRESS` | Enable ingress configuration non-interactively |
+
+When specifying ingress information you may also set the **port number** that should be used by the ingress backend. If omitted, Aspir8 will use the first internal port defined for the service.

--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -67,6 +67,11 @@ public class ConfigureIngressAction(
                         .PromptStyle("yellow")
                         .AllowEmpty());
 
+                var port = Logger.Prompt(
+                    new TextPrompt<int?>($"[bold]Enter service port for [blue]{service}[/] (leave blank for default): [/]")
+                        .PromptStyle("yellow")
+                        .AllowEmpty());
+
                 var annotations = new Dictionary<string, string>();
                 while (true)
                 {
@@ -94,7 +99,8 @@ public class ConfigureIngressAction(
                 {
                     Host = host,
                     Path = "/",
-                    TlsSecret = string.IsNullOrWhiteSpace(tls) ? null : tls
+                    TlsSecret = string.IsNullOrWhiteSpace(tls) ? null : tls,
+                    PortNumber = port
                 };
             }
 

--- a/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
@@ -289,7 +289,9 @@ public static class KubernetesDeploymentDataExtensions
         var labels = data.ToKubernetesLabels();
         var metadata = data.ToKubernetesObjectMetaData(labels);
 
-        var servicePort = data.Ports.FirstOrDefault()?.InternalPort ?? 80;
+        var servicePort = data.IngressPortNumber
+            ?? data.Ports.FirstOrDefault()?.InternalPort
+            ?? 80;
 
         var ingress = new V1Ingress
         {
@@ -432,7 +434,8 @@ public static class KubernetesDeploymentDataExtensions
                 .SetIngressEnabled(true)
                 .SetIngressHost(def.Host)
                 .SetIngressTlsSecret(def.TlsSecret)
-                .SetIngressPath(def.Path);
+                .SetIngressPath(def.Path)
+                .SetIngressPortNumber(def.PortNumber);
         }
 
         return data;

--- a/src/Aspirate.Shared/Models/Aspirate/IngressDefinition.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/IngressDefinition.cs
@@ -19,4 +19,9 @@ public sealed class IngressDefinition
     /// Optional TLS secret name.
     /// </summary>
     public string? TlsSecret { get; set; }
+
+    /// <summary>
+    /// Optional service port number to use for the ingress backend.
+    /// </summary>
+    public int? PortNumber { get; set; }
 }

--- a/src/Aspirate.Shared/Models/Aspirate/KubernetesDeploymentData.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/KubernetesDeploymentData.cs
@@ -28,6 +28,7 @@ public class KubernetesDeploymentData
     public string? IngressHost { get; private set; }
     public string? IngressTlsSecret { get; private set; }
     public string? IngressPath { get; private set; }
+    public int? IngressPortNumber { get; private set; }
     public BicepResource? Deployment { get; private set; }
 
     public KubernetesDeploymentData SetName(string name)
@@ -158,6 +159,12 @@ public class KubernetesDeploymentData
     public KubernetesDeploymentData SetIngressPath(string? path)
     {
         IngressPath = path;
+        return this;
+    }
+
+    public KubernetesDeploymentData SetIngressPortNumber(int? port)
+    {
+        IngressPortNumber = port;
         return this;
     }
 

--- a/tests/Aspirate.Tests/ExtensionTests/KubernetesDeploymentDataExtensionTests.cs
+++ b/tests/Aspirate.Tests/ExtensionTests/KubernetesDeploymentDataExtensionTests.cs
@@ -116,7 +116,7 @@ public class KubernetesDeploymentDataExtensionTests
         // Assert
         result.Spec.Ports[0].Name.Should().Be("test-port");
         result.Spec.Ports[0].Port.Should().Be(8080);
-        result.Spec.Ports[0].TargetPort.Value.Should().Be(8080);
+        result.Spec.Ports[0].TargetPort.Value.Should().Be("8080");
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class KubernetesDeploymentDataExtensionTests
         // Assert
         result.Spec.Ports[0].Name.Should().Be("test-port");
         result.Spec.Ports[0].Port.Should().Be(80);
-        result.Spec.Ports[0].TargetPort.Value.Should().Be(8080);
+        result.Spec.Ports[0].TargetPort.Value.Should().Be("8080");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- support configurable ingress port through `PortNumber`
- set ingress port in Kubernetes deployment and CLI
- document ingress port usage
- adjust tests for target port string

## Testing
- `dotnet build Aspirate.sln`
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj -v minimal` *(fails: Expected exception message to match)*

------
https://chatgpt.com/codex/tasks/task_e_686f479f270c8331b406df5ae89ae670