### PR TITLE
Update ingress docs

### DIFF
--- a/docs/Writerside/topics/Generate-Command.md
+++ b/docs/Writerside/topics/Generate-Command.md
@@ -63,6 +63,9 @@ AWS CloudFormation templates can be referenced in your manifest using `aws.cloud
 
 When running interactively with ingress enabled, `aspirate` prompts for annotations for each selected external service alongside the host and TLS secret questions. The supplied values are persisted in the state file so they can be reused on subsequent runs. Annotations are configured separately and are **not** read from `manifest.json`.
 
+For details on how binding ports map to Services and how to choose the port used
+by Ingress, see [Ingress Support](Ingress-Support.md#service-port-translation).
+
 ##Specify components when running with `--non-interactive`
 When ran non-interactively, you can specify which components to build with `-c` or `--components`. Example: `-c webApi -c frontend -c sql -c redis`.
 

--- a/docs/Writerside/topics/Ingress-Support.md
+++ b/docs/Writerside/topics/Ingress-Support.md
@@ -23,3 +23,15 @@ aspirate run --with-ingress
 | --with-ingress | `ASPIRATE_WITH_INGRESS` | Enable ingress configuration non-interactively |
 
 When specifying ingress information you may also set the **port number** that should be used by the ingress backend. If omitted, Aspir8 will use the first internal port defined for the service.
+
+## Service port translation
+
+Bindings defined on resources include `port` and `targetPort` values. During
+generation these translate directly to a Kubernetes Service's `port` and
+`targetPort` respectively. When `port` is omitted the value of
+`targetPort` is used for both fields.
+
+The Ingress backend forwards traffic to one of the Service ports. By default the
+first internal port (the first binding's `targetPort`) is selected. Using the
+optional ingress port number introduced in Issue 2 you can explicitly set which
+Service port the Ingress rule should use.


### PR DESCRIPTION
## Summary
- document how service bindings map to Kubernetes ports
- describe default ingress backend port behaviour
- cross-reference new info from the generate command docs

## Testing
- `dotnet test` *(fails: 65 failed, 270 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686f4c56884483319d2cb6d4f63496c0