### PR TITLE
Update ingress configuration to scan manifest for external bindings

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -1,4 +1,5 @@
 using Aspirate.Shared.Literals;
+using Aspirate.Shared.Extensions;
 
 namespace Aspirate.Commands.Actions.Manifests;
 
@@ -34,10 +35,7 @@ public class ConfigureIngressAction(
         CurrentState.IngressDefinitions ??= new();
         CurrentState.ResourceAnnotations ??= new();
 
-        var candidates = CurrentState.AllSelectedSupportedComponents
-            .Where(r => r.Value is IResourceWithBinding res &&
-                        res.Bindings != null &&
-                        res.Bindings.Values.Any(b => b.External))
+        var candidates = CurrentState.GetResourcesWithExternalBindings()
             .Select(r => r.Key)
             .ToList();
 

--- a/src/Aspirate.Shared/Extensions/AspirateStateExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/AspirateStateExtensions.cs
@@ -62,4 +62,19 @@ public static class AspirateStateExtensions
 
         currentState.SecretState = previousState.SecretState;
     }
+
+    /// <summary>
+    /// Returns all manifest resources that define at least one external binding.
+    /// </summary>
+    /// <param name="state">The <see cref="AspirateState"/> instance.</param>
+    /// <returns>A collection of resources with external bindings.</returns>
+    public static IEnumerable<KeyValuePair<string, Resource>> GetResourcesWithExternalBindings(this AspirateState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        return state.LoadedAspireManifestResources
+            .Where(r => r.Value is IResourceWithBinding res &&
+                        res.Bindings != null &&
+                        res.Bindings.Values.Any(b => b.External));
+    }
 }

--- a/tests/Aspirate.Tests/ExtensionTests/AspirateStateExtensionsTests.cs
+++ b/tests/Aspirate.Tests/ExtensionTests/AspirateStateExtensionsTests.cs
@@ -3,6 +3,9 @@ using Aspirate.Shared.Extensions;
 using Aspirate.Shared.Interfaces.Commands;
 using Aspirate.Shared.Interfaces.Commands.Contracts;
 using Aspirate.Shared.Models.Aspirate;
+using Aspirate.Shared.Models.AspireManifests.Components.Common;
+using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Xunit;
 
@@ -41,5 +44,49 @@ public class AspirateStateExtensionsTests
 
         // Assert
         state.ContainerBuilder.Should().Be(ContainerBuilder.Docker.Value);
+    }
+
+    [Fact]
+    public void GetResourcesWithExternalBindings_ReturnsExpectedResources()
+    {
+        // Arrange
+        var state = new AspirateState
+        {
+            LoadedAspireManifestResources = new Dictionary<string, Resource>
+            {
+                ["web"] = new ProjectResource
+                {
+                    Bindings = new Dictionary<string, Binding>
+                    {
+                        ["http"] = new Binding
+                        {
+                            Scheme = "http",
+                            Protocol = "tcp",
+                            Transport = "http",
+                            External = true
+                        }
+                    }
+                },
+                ["internal"] = new ProjectResource
+                {
+                    Bindings = new Dictionary<string, Binding>
+                    {
+                        ["http"] = new Binding
+                        {
+                            Scheme = "http",
+                            Protocol = "tcp",
+                            Transport = "http",
+                            External = false
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var results = state.GetResourcesWithExternalBindings().Select(r => r.Key).ToList();
+
+        // Assert
+        results.Should().ContainSingle().Which.Should().Be("web");
     }
 }


### PR DESCRIPTION
## Summary
- extend `AspirateStateExtensions` with `GetResourcesWithExternalBindings`
- use this new helper in `ConfigureIngressAction`
- test that the helper returns resources with `external` bindings

## Testing
- `~/.dotnet/dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --verbosity minimal` *(fails: 65 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686f4f95fd3883318dd0e1d19851f8b3