### PR TITLE
Fix ingress port selection

### DIFF
--- a/docs/Writerside/topics/Ingress-Support.md
+++ b/docs/Writerside/topics/Ingress-Support.md
@@ -28,10 +28,10 @@ When specifying ingress information you may also set the **port number** that sh
 
 Bindings defined on resources include `port` and `targetPort` values. During
 generation these translate directly to a Kubernetes Service's `port` and
-`targetPort` respectively. When `port` is omitted the value of
+`targetPort` respectively. If a binding omits `port`, the value of
 `targetPort` is used for both fields.
 
-The Ingress backend forwards traffic to one of the Service ports. By default the
-first internal port (the first binding's `targetPort`) is selected. Using the
-optional ingress port number introduced in Issue 2 you can explicitly set which
-Service port the Ingress rule should use.
+Ingress forwards traffic to the Service's `port`. When no `port` is specified
+for a binding, that Service port defaults to the `targetPort` value. You can use
+the optional ingress port number to select which Service port the Ingress rule
+should forward traffic to.

--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -79,7 +79,7 @@ public class ConfigureIngressAction(
                             .UseConverter(b => $"{b.Key} ({b.Value.Scheme}:{b.Value.TargetPort})")
                             .AddChoices(bindings));
 
-                var port = selectedBinding.Value.TargetPort;
+                var port = selectedBinding.Value.Port ?? selectedBinding.Value.TargetPort;
 
                 var annotations = new Dictionary<string, string>();
                 while (true)

--- a/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
@@ -289,8 +289,10 @@ public static class KubernetesDeploymentDataExtensions
         var labels = data.ToKubernetesLabels();
         var metadata = data.ToKubernetesObjectMetaData(labels);
 
+        var firstPort = data.Ports.FirstOrDefault();
         var servicePort = data.IngressPortNumber
-            ?? data.Ports.FirstOrDefault()?.InternalPort
+            ?? (firstPort?.ExternalPort > 0 ? firstPort.ExternalPort : (int?)null)
+            ?? firstPort?.InternalPort
             ?? 80;
 
         var ingress = new V1Ingress

--- a/tests/Aspirate.Tests/ExtensionTests/KubernetesIngressTests.cs
+++ b/tests/Aspirate.Tests/ExtensionTests/KubernetesIngressTests.cs
@@ -37,4 +37,20 @@ public class KubernetesIngressTests
 
         objects.OfType<V1Ingress>().Should().ContainSingle();
     }
+
+    [Fact]
+    public void ToKubernetesIngress_UsesBindingPort_WhenDifferentFromTargetPort()
+    {
+        var data = new KubernetesDeploymentData()
+            .SetName("web")
+            .SetContainerImage("test")
+            .SetIngressEnabled(true)
+            .SetIngressHost("example.com")
+            .SetIngressPath("/")
+            .SetPorts(new List<Ports> { new Ports { Name = "http", InternalPort = 8080, ExternalPort = 80 } });
+
+        var ingress = data.ToKubernetesIngress();
+
+        ingress.Spec.Rules.First().Http.Paths.First().Backend.Service.Port.Number.Should().Be(80);
+    }
 }


### PR DESCRIPTION
## Summary
- capture external binding port when configuring ingress
- prefer service port over targetPort when creating an ingress
- document service port forwarding behaviour
- test ingress uses binding port when different from targetPort

## Testing
- `dotnet test` *(fails: NullReferenceException in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_686f608e9cb883318146af47dfc0cce2