### PR TITLE
Allow multiple ingress hosts

### DIFF
--- a/docs/Writerside/topics/Generate-Command.md
+++ b/docs/Writerside/topics/Generate-Command.md
@@ -61,7 +61,7 @@ AWS CloudFormation templates can be referenced in your manifest using `aws.cloud
 
 `aspirate` accepts additional fields beyond the official .NET Aspire schema. These extra fields are treated as extensions and are preserved when reading and writing manifest files.
 
-When running interactively with ingress enabled, `aspirate` prompts for annotations for each selected external service alongside the host and TLS secret questions. The supplied values are persisted in the state file so they can be reused on subsequent runs. Annotations are configured separately and are **not** read from `manifest.json`.
+When running interactively with ingress enabled, `aspirate` prompts for annotations for each selected external service alongside the host names and TLS secret questions. The supplied values are persisted in the state file so they can be reused on subsequent runs. Annotations are configured separately and are **not** read from `manifest.json`.
 
 For details on how binding ports map to Services and how to choose the port used
 by Ingress, see [Ingress Support](Ingress-Support.md#service-port-translation).

--- a/docs/Writerside/topics/Ingress-Support.md
+++ b/docs/Writerside/topics/Ingress-Support.md
@@ -2,7 +2,7 @@
 
 Aspir8 can optionally generate Kubernetes Ingress resources for services that expose HTTP bindings.
 During `generate` or `run` you will be prompted to select the services you wish to expose. For each
-service you can provide a host name, optional service port, and optional TLS secret. Selected values are stored in the
+service you can provide one or more host names, an optional service port, and optional TLS secret. Selected values are stored in the
 project state so subsequent runs reuse them.
 
 When enabled, Aspir8 will also offer to deploy the NGINX ingress controller if it is not found

--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -57,9 +57,28 @@ public class ConfigureIngressAction(
 
             foreach (var service in selected)
             {
-                var host = Logger.Prompt(
-                    new TextPrompt<string>($"[bold]Enter host for service [blue]{service}[/]: [/]")
-                        .PromptStyle("yellow"));
+                var hosts = new List<string>();
+
+                while (true)
+                {
+                    var host = Logger.Prompt(
+                        new TextPrompt<string>($"[bold]Enter host for service [blue]{service}[/] (leave blank to stop): [/]")
+                            .PromptStyle("yellow")
+                            .AllowEmpty());
+
+                    if (string.IsNullOrWhiteSpace(host))
+                    {
+                        if (hosts.Count == 0)
+                        {
+                            Logger.MarkupLine("[red]A host is required.[/]");
+                            continue;
+                        }
+
+                        break;
+                    }
+
+                    hosts.Add(host);
+                }
 
                 var tls = Logger.Prompt(
                     new TextPrompt<string>($"[bold]Enter TLS secret for service [blue]{service}[/] (leave blank if none): [/]")
@@ -106,7 +125,7 @@ public class ConfigureIngressAction(
 
                 CurrentState.IngressDefinitions[service] = new IngressDefinition
                 {
-                    Host = host,
+                    Hosts = hosts,
                     Path = "/",
                     TlsSecret = string.IsNullOrWhiteSpace(tls) ? null : tls,
                     PortNumber = port

--- a/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
@@ -303,32 +303,29 @@ public static class KubernetesDeploymentDataExtensions
             Spec = new V1IngressSpec
             {
                 IngressClassName = "nginx",
-                Rules =
-                [
-                    new V1IngressRule
+                Rules = data.IngressHosts.Select(h => new V1IngressRule
+                {
+                    Host = h,
+                    Http = new V1HTTPIngressRuleValue
                     {
-                        Host = data.IngressHost,
-                        Http = new V1HTTPIngressRuleValue
-                        {
-                            Paths =
-                            [
-                                new V1HTTPIngressPath
+                        Paths =
+                        [
+                            new V1HTTPIngressPath
+                            {
+                                Path = data.IngressPath ?? "/",
+                                PathType = "Prefix",
+                                Backend = new V1IngressBackend
                                 {
-                                    Path = data.IngressPath ?? "/",
-                                    PathType = "Prefix",
-                                    Backend = new V1IngressBackend
+                                    Service = new V1IngressServiceBackend
                                     {
-                                        Service = new V1IngressServiceBackend
-                                        {
-                                            Name = data.Name,
-                                            Port = new V1ServiceBackendPort { Number = servicePort }
-                                        }
+                                        Name = data.Name,
+                                        Port = new V1ServiceBackendPort { Number = servicePort }
                                     }
                                 }
-                            ]
-                        }
+                            }
+                        ]
                     }
-                ]
+                }).ToList()
             }
         };
 
@@ -339,7 +336,7 @@ public static class KubernetesDeploymentDataExtensions
                 new V1IngressTLS
                 {
                     SecretName = data.IngressTlsSecret,
-                    Hosts = [ data.IngressHost ]
+                    Hosts = data.IngressHosts.ToList(),
                 }
             ];
         }
@@ -434,7 +431,7 @@ public static class KubernetesDeploymentDataExtensions
         {
             data
                 .SetIngressEnabled(true)
-                .SetIngressHost(def.Host)
+                .SetIngressHosts(def.Hosts)
                 .SetIngressTlsSecret(def.TlsSecret)
                 .SetIngressPath(def.Path)
                 .SetIngressPortNumber(def.PortNumber);

--- a/src/Aspirate.Shared/Models/Aspirate/IngressDefinition.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/IngressDefinition.cs
@@ -1,3 +1,6 @@
+using System.Text.Json.Serialization;
+using System.Linq;
+
 namespace Aspirate.Shared.Models.Aspirate;
 
 /// <summary>
@@ -6,9 +9,22 @@ namespace Aspirate.Shared.Models.Aspirate;
 public sealed class IngressDefinition
 {
     /// <summary>
-    /// Host name for the ingress rule.
+    /// Host names for the ingress rule.
     /// </summary>
-    public required string Host { get; set; }
+    public List<string> Hosts { get; set; } = [];
+
+    [JsonPropertyName("host")]
+    public string? LegacyHost
+    {
+        get => Hosts.FirstOrDefault();
+        set
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                Hosts = [ value ];
+            }
+        }
+    }
 
     /// <summary>
     /// Path for the ingress rule. Defaults to '/'.

--- a/src/Aspirate.Shared/Models/Aspirate/KubernetesDeploymentData.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/KubernetesDeploymentData.cs
@@ -25,7 +25,7 @@ public class KubernetesDeploymentData
     public string? ImagePullPolicy {get; private set;}
     public string? ServiceType { get; private set; } = "ClusterIP";
     public bool? IngressEnabled { get; private set; } = false;
-    public string? IngressHost { get; private set; }
+    public IReadOnlyCollection<string> IngressHosts { get; private set; } = [];
     public string? IngressTlsSecret { get; private set; }
     public string? IngressPath { get; private set; }
     public int? IngressPortNumber { get; private set; }
@@ -144,9 +144,9 @@ public class KubernetesDeploymentData
         return this;
     }
 
-    public KubernetesDeploymentData SetIngressHost(string? host)
+    public KubernetesDeploymentData SetIngressHosts(IReadOnlyCollection<string> hosts)
     {
-        IngressHost = host;
+        IngressHosts = hosts;
         return this;
     }
 

--- a/tests/Aspirate.Tests/ExtensionTests/KubernetesIngressTests.cs
+++ b/tests/Aspirate.Tests/ExtensionTests/KubernetesIngressTests.cs
@@ -11,7 +11,7 @@ public class KubernetesIngressTests
             .SetName("web")
             .SetContainerImage("test")
             .SetIngressEnabled(true)
-            .SetIngressHost("example.com")
+            .SetIngressHosts(["example.com"])
             .SetIngressPath("/")
             .SetIngressTlsSecret("tls")
             .SetPorts(new List<Ports> { new Ports { Name = "http", InternalPort = 8080 } });
@@ -29,7 +29,7 @@ public class KubernetesIngressTests
             .SetName("web")
             .SetContainerImage("test")
             .SetIngressEnabled(true)
-            .SetIngressHost("example.com")
+            .SetIngressHosts(["example.com"])
             .SetIngressPath("/")
             .SetPorts(new List<Ports> { new Ports { Name = "http", InternalPort = 8080 } });
 
@@ -45,7 +45,7 @@ public class KubernetesIngressTests
             .SetName("web")
             .SetContainerImage("test")
             .SetIngressEnabled(true)
-            .SetIngressHost("example.com")
+            .SetIngressHosts(["example.com"])
             .SetIngressPath("/")
             .SetPorts(new List<Ports> { new Ports { Name = "http", InternalPort = 8080, ExternalPort = 80 } });
 


### PR DESCRIPTION
## Summary
- support multiple ingress hosts in state and manifest generation
- update ConfigureIngressAction to collect multiple hostnames
- adjust tests and docs for new behaviour

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686f7c79adcc8331a9c49c2783be7952