### PR TITLE
Add option to select all ingress services

### DIFF
--- a/docs/Writerside/topics/Ingress-Support.md
+++ b/docs/Writerside/topics/Ingress-Support.md
@@ -1,9 +1,9 @@
 # Ingress Support
 
 Aspir8 can optionally generate Kubernetes Ingress resources for services that expose HTTP bindings.
-During `generate` or `run` you will be prompted to select the services you wish to expose. For each
-service you can provide one or more host names, an optional service port, and optional TLS secret. Selected values are stored in the
-project state so subsequent runs reuse them.
+During `generate` or `run` you will be prompted to select the services you wish to expose. When multiple services are available the prompt includes an
+"All Services" group so you can quickly select every option. For each service you can provide one or more host names,
+an optional service port, and optional TLS secret. Selected values are stored in the project state so subsequent runs reuse them.
 
 When enabled, Aspir8 will also offer to deploy the NGINX ingress controller if it is not found
 in the target cluster.

--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -53,7 +53,10 @@ public class ConfigureIngressAction(
                     .Title("Select [green]services[/] to expose via ingress")
                     .PageSize(10)
                     .MoreChoicesText("[grey](Move up and down to reveal more services)[/]")
-                    .AddChoices(candidates));
+                    .InstructionsText(
+                        "[grey](Press [blue]<space>[/] to toggle a service, " +
+                        "[green]<enter>[/] to accept)[/]")
+                    .AddChoiceGroup("All Services", candidates));
 
             foreach (var service in selected)
             {


### PR DESCRIPTION
## Summary
- allow selecting all services when configuring ingress
- document the "All Services" group

## Testing
- `dotnet tool restore`
- `dotnet cake` *(fails: NETSDK1045 errors and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686f8279aa2c83318de51d93d59c2204