### PR TITLE
Add ingress docs to navigation

### DIFF
--- a/docs/Writerside/hi.tree
+++ b/docs/Writerside/hi.tree
@@ -32,6 +32,7 @@
     <toc-element topic="Configurable-State-Path.md"/>
     <toc-element topic="File-Permissions.md"/>
     <toc-element topic="External-Providers.md"/>
+    <toc-element topic="Ingress-Support.md"/>
     <toc-element topic="Dapr-Support.md"/>
     <toc-element topic="Security-Best-Practices.md"/>
     <toc-element topic="Troubleshooting.md"/>


### PR DESCRIPTION
## Summary
- include Ingress Support page in Writerside table of contents

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f84baa25c83319e687999174a608f