### PR TITLE
Handle ingress annotations separately

### DIFF
--- a/docs/Writerside/topics/Generate-Command.md
+++ b/docs/Writerside/topics/Generate-Command.md
@@ -61,7 +61,7 @@ AWS CloudFormation templates can be referenced in your manifest using `aws.cloud
 
 `aspirate` accepts additional fields beyond the official .NET Aspire schema. These extra fields are treated as extensions and are preserved when reading and writing manifest files.
 
-When running interactively, `aspirate` prompts for annotations for each selected external service alongside the host names and TLS secret questions. The supplied values are persisted in the state file so they can be reused on subsequent runs. Annotations are configured separately and are **not** read from `manifest.json`.
+When running interactively, `aspirate` prompts for ingress annotations for each selected external service alongside the host names and TLS secret questions. The supplied values are persisted in the state file so they can be reused on subsequent runs. These annotations apply only to the generated Ingress resource and are **not** read from `manifest.json`.
 
 For details on how binding ports map to Services and how to choose the port used
 by Ingress, see [Ingress Support](Ingress-Support.md#service-port-translation).

--- a/docs/Writerside/topics/Ingress-Support.md
+++ b/docs/Writerside/topics/Ingress-Support.md
@@ -3,7 +3,7 @@
 Aspir8 can optionally generate Kubernetes Ingress resources for services that expose HTTP bindings.
 When running interactively, Aspir8 automatically prompts you to select the services you wish to expose whenever external bindings are detected. When multiple services are available the prompt includes an
 "All Services" group so you can quickly select every option. For each service you can provide one or more host names,
-an optional service port, and optional TLS secret. Selected values are stored in the project state so subsequent runs reuse them.
+an optional service port, optional TLS secret, and optional ingress annotations. Selected values are stored in the project state so subsequent runs reuse them.
 
 When enabled, Aspir8 will also offer to deploy the NGINX ingress controller if it is not found
 in the target cluster.

--- a/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ConfigureIngressAction.cs
@@ -30,7 +30,6 @@ public class ConfigureIngressAction(
 
 
         CurrentState.IngressDefinitions ??= new();
-        CurrentState.ResourceAnnotations ??= new();
 
         if (!CurrentState.NonInteractive)
         {
@@ -107,17 +106,13 @@ public class ConfigureIngressAction(
                     annotations[key] = value;
                 }
 
-                if (annotations.Count > 0)
-                {
-                    CurrentState.ResourceAnnotations[service] = annotations;
-                }
-
                 CurrentState.IngressDefinitions[service] = new IngressDefinition
                 {
                     Hosts = hosts,
                     Path = "/",
                     TlsSecret = string.IsNullOrWhiteSpace(tls) ? null : tls,
-                    PortNumber = port
+                    PortNumber = port,
+                    Annotations = annotations.Count > 0 ? annotations : null
                 };
             }
 

--- a/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
@@ -284,10 +284,19 @@ public static class KubernetesDeploymentDataExtensions
         };
     }
 
-    public static V1Ingress ToKubernetesIngress(this KubernetesDeploymentData data)
+public static V1Ingress ToKubernetesIngress(this KubernetesDeploymentData data)
+{
+    var labels = data.ToKubernetesLabels();
+    var metadata = data.ToKubernetesObjectMetaData(labels);
+
+    if (data.IngressAnnotations.Count > 0)
     {
-        var labels = data.ToKubernetesLabels();
-        var metadata = data.ToKubernetesObjectMetaData(labels);
+        metadata.Annotations ??= new Dictionary<string, string>();
+        foreach (var annotation in data.IngressAnnotations)
+        {
+            metadata.Annotations[annotation.Key] = annotation.Value;
+        }
+    }
 
         var firstPort = data.Ports.FirstOrDefault();
         var servicePort = data.IngressPortNumber
@@ -434,7 +443,8 @@ public static class KubernetesDeploymentDataExtensions
                 .SetIngressHosts(def.Hosts)
                 .SetIngressTlsSecret(def.TlsSecret)
                 .SetIngressPath(def.Path)
-                .SetIngressPortNumber(def.PortNumber);
+                .SetIngressPortNumber(def.PortNumber)
+                .SetIngressAnnotations(def.Annotations);
         }
 
         return data;

--- a/src/Aspirate.Shared/Models/Aspirate/IngressDefinition.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/IngressDefinition.cs
@@ -24,4 +24,9 @@ public sealed class IngressDefinition
     /// Optional service port number to use for the ingress backend.
     /// </summary>
     public int? PortNumber { get; set; }
+
+    /// <summary>
+    /// Optional annotations to apply to the ingress resource.
+    /// </summary>
+    public Dictionary<string, string>? Annotations { get; set; }
 }

--- a/src/Aspirate.Shared/Models/Aspirate/KubernetesDeploymentData.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/KubernetesDeploymentData.cs
@@ -11,6 +11,7 @@ public class KubernetesDeploymentData
     public Dictionary<string, string?> Env { get; private set; } = [];
     public Dictionary<string, string?> Secrets { get; private set; } = [];
     public Dictionary<string, string> Annotations { get; private set; } = [];
+    public Dictionary<string, string> IngressAnnotations { get; private set; } = [];
     public IReadOnlyCollection<Volume> Volumes { get; private set; } = [];
     public IReadOnlyCollection<BindMount> BindMounts { get; private set; } = [];
     public IReadOnlyCollection<Ports> Ports { get; private set; } = [];
@@ -63,6 +64,12 @@ public class KubernetesDeploymentData
     public KubernetesDeploymentData SetAnnotations(Dictionary<string, string>? annotations)
     {
         Annotations = annotations ?? [];
+        return this;
+    }
+
+    public KubernetesDeploymentData SetIngressAnnotations(Dictionary<string, string>? annotations)
+    {
+        IngressAnnotations = annotations ?? [];
         return this;
     }
 
@@ -224,6 +231,7 @@ public class KubernetesDeploymentData
     public bool HasBindMounts => BindMounts.Count > 0;
     public bool HasAnySecrets => Secrets.Count > 0 && SecretsDisabled != true;
     public bool HasAnyAnnotations => Annotations.Count > 0;
+    public bool HasIngressAnnotations => IngressAnnotations.Count > 0;
     public bool HasArgs => Args.Count > 0;
     public bool HasAnyEnv => Env.Count > 0;
     public bool WithNamespace => !string.IsNullOrWhiteSpace(Namespace);

--- a/tests/Aspirate.Tests/ExtensionTests/KubernetesIngressTests.cs
+++ b/tests/Aspirate.Tests/ExtensionTests/KubernetesIngressTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Xunit;
 
 namespace Aspirate.Tests.ExtensionTests;
@@ -14,12 +15,14 @@ public class KubernetesIngressTests
             .SetIngressHosts(["example.com"])
             .SetIngressPath("/")
             .SetIngressTlsSecret("tls")
-            .SetPorts(new List<Ports> { new Ports { Name = "http", InternalPort = 8080 } });
+            .SetPorts(new List<Ports> { new Ports { Name = "http", InternalPort = 8080 } })
+            .SetIngressAnnotations(new Dictionary<string, string> { { "test", "value" } });
 
         var ingress = data.ToKubernetesIngress();
 
         ingress.Spec.Rules.First().Host.Should().Be("example.com");
         ingress.Spec.Tls.First().SecretName.Should().Be("tls");
+        ingress.Metadata.Annotations.Should().ContainKey("test").WhoseValue.Should().Be("value");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- store ingress annotations directly in `IngressDefinition`
- capture ingress annotations in the configuration step
- surface an `IngressAnnotations` property on `KubernetesDeploymentData`
- apply ingress annotations only to Ingress resources
- update docs and tests

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj` *(fails: 44 failed, 293 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686fae2697e08331a986c83b247793b7