### PR TITLE
Fix destroy overlay secrets

### DIFF
--- a/tests/Aspirate.Tests/ActionsTests/Manifests/RemoveManifestsToClusterActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Manifests/RemoveManifestsToClusterActionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Aspirate.Cli;
 using Xunit;
 
 namespace Aspirate.Tests.ActionsTests.Manifests;
@@ -107,5 +108,64 @@ public class RemoveManifestsToClusterActionTests : BaseActionTests<RemoveManifes
 
         // Assert
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteRemoveManifestsToClusterActionTests_WithOverlayInput_Success()
+    {
+        // Arrange
+        var overlayPath = "/overlay";
+        var outputPath = "/overlay/aspirate-output";
+
+        var secretState = new SecretState
+        {
+            Secrets = new Dictionary<string, Dictionary<string, string>>
+            {
+                ["postgrescontainer"] = new()
+                {
+                    ["ConnectionString_Test"] = "dummy"
+                }
+            }
+        };
+
+        var state = CreateAspirateState(nonInteractive: true, projectPath: DefaultProjectPath, inputPath: overlayPath, kubeContext: "docker-desktop");
+        state.OutputPath = outputPath;
+        state.SecretState = secretState;
+
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddDirectory(overlayPath);
+        fileSystem.AddDirectory(fileSystem.Path.Combine(outputPath, "postgrescontainer"));
+
+        var kubeCtl = Substitute.For<IKubeCtlService>();
+        kubeCtl.RemoveManifests(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(ci => Task.FromResult(fileSystem.File.Exists(fileSystem.Path.Combine(outputPath, "postgrescontainer", ".postgrescontainer.secrets"))));
+
+        var secretProvider = new SecretProvider(fileSystem);
+
+        var services = new ServiceCollection();
+        services.RegisterAspirateEssential();
+        services.RemoveAll<IFileSystem>();
+        services.RemoveAll<IShellExecutionService>();
+        services.RemoveAll<AspirateState>();
+        services.RemoveAll<IKubeCtlService>();
+        services.RemoveAll<SecretProvider>();
+
+        services.AddSingleton<IFileSystem>(fileSystem);
+        services.AddSingleton(secretProvider);
+        services.AddSingleton<IAnsiConsole>(new TestConsole());
+        services.AddSingleton(state);
+        services.AddSingleton(Substitute.For<IShellExecutionService>());
+        services.AddSingleton(kubeCtl);
+
+        var provider = services.BuildServiceProvider();
+
+        var action = GetSystemUnderTest(provider);
+
+        // Act
+        var result = await action.ExecuteAsync();
+
+        // Assert
+        result.Should().BeTrue();
+        await kubeCtl.Received().RemoveManifests(state.KubeContext!, overlayPath);
     }
 }


### PR DESCRIPTION
## Summary
- support overlays referencing aspirate-generated components when creating secret files
- add coverage for aspirate destroy with overlay input

## Testing
- `dotnet test` *(fails: Repository has no remote, VerifyException, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68708ed9403c8331bb5430c6d7be2d67