### PR TITLE
Fix secret env files path for kustomize apply

### DIFF
--- a/src/Aspirate.Services/Implementations/KustomizeService.cs
+++ b/src/Aspirate.Services/Implementations/KustomizeService.cs
@@ -55,11 +55,20 @@ public class KustomizeService(IFileSystem fileSystem, IShellExecutionService she
             return;
         }
 
-        var tempPath = fileSystem.Path.GetTempPath();
+        var basePath = !string.IsNullOrEmpty(state.InputPath)
+            ? state.InputPath
+            : fileSystem.Path.GetTempPath();
 
         foreach (var resourceSecrets in secretProvider.State.Secrets.Where(x => x.Value.Keys.Count > 0))
         {
-            var secretFile = fileSystem.Path.Combine(tempPath, $"{resourceSecrets.Key}.{Path.GetRandomFileName()}.secrets");
+            var resourcePath = fileSystem.Path.Combine(basePath, resourceSecrets.Key);
+
+            if (!fileSystem.Directory.Exists(resourcePath))
+            {
+                continue;
+            }
+
+            var secretFile = fileSystem.Path.Combine(resourcePath, $".{resourceSecrets.Key}.secrets");
 
             files.Add(secretFile);
 

--- a/tests/Aspirate.Tests/ServiceTests/KustomizeServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/KustomizeServiceTests.cs
@@ -11,7 +11,9 @@ public class KustomizeServiceTests : AspirateTestBase
     {
         // Arrange
         var fs = new MockFileSystem();
-        fs.AddDirectory(fs.Path.GetTempPath());
+        fs.AddDirectory("/input");
+        fs.AddDirectory("/input/postgrescontainer");
+        fs.AddDirectory("/input/postgrescontainer2");
 
         var shellExecutionService = Substitute.For<IShellExecutionService>();
         var console = Substitute.For<IAnsiConsole>();
@@ -19,6 +21,7 @@ public class KustomizeServiceTests : AspirateTestBase
         var sut = new KustomizeService(fs, shellExecutionService, console, manifestWriter);
 
         var state = CreateAspirateStateWithConnectionStrings();
+        state.InputPath = "/input";
         state.SecretState = new SecretState
         {
             Secrets = new()


### PR DESCRIPTION
## Summary
- ensure KustomizeService writes `.secrets` files into the manifests input path
- adapt unit test to new location for secret files

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: `dotnet` 9.0 not available)*

------
https://chatgpt.com/codex/tasks/task_e_6870bb4c54bc8331a9220580dc7764da