### PR TITLE
Fix envFrom secret placement

### DIFF
--- a/src/Aspirate.Cli/Templates/deployment.hbs
+++ b/src/Aspirate.Cli/Templates/deployment.hbs
@@ -59,10 +59,16 @@ spec:
         envFrom:
         - configMapRef:
             name: {{name}}-env
-        {{/if}}
         {{#if hasAnySecrets}}
         - secretRef:
             name: {{name}}-secrets
+        {{/if}}
+        {{else}}
+        {{#if hasAnySecrets}}
+        envFrom:
+        - secretRef:
+            name: {{name}}-secrets
+        {{/if}}
         {{/if}}
         {{#if hasVolumes}}
         volumeMounts:

--- a/src/Aspirate.Cli/Templates/statefulset.hbs
+++ b/src/Aspirate.Cli/Templates/statefulset.hbs
@@ -56,10 +56,16 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{name}}-env
-          {{/if}}
-          {{#if hasAnySecrets}}
+            {{#if hasAnySecrets}}
             - secretRef:
                 name: {{name}}-secrets
+            {{/if}}
+          {{else}}
+          {{#if hasAnySecrets}}
+          envFrom:
+            - secretRef:
+                name: {{name}}-secrets
+          {{/if}}
           {{/if}}
       {{#if hasVolumes}}
           volumeMounts:


### PR DESCRIPTION
## Summary
- adjust secretRef placement under envFrom for deployments and statefulsets

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj` *(fails: NETSDK1045, SDK for .NET 9.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870c04027748331915219cfdcd79b30