### PR TITLE
Fix settings logo show exception

### DIFF
--- a/src/Aspirate.Commands/Commands/GenericCommand.cs
+++ b/src/Aspirate.Commands/Commands/GenericCommand.cs
@@ -5,7 +5,23 @@ public class GenericCommand : Command
 {
     public GenericCommand(string name, string description)
         : base(name, description) =>
-        Action = CommandHandler.Create<IServiceCollection>(ExecuteCommand);
+        Action = CommandHandler.Create(InvokeCommand);
+
+    private Task<int> InvokeCommand()
+    {
+        var services = new ServiceCollection();
+        services
+            .AddSecretProtectionStrategies()
+            .AddAspirateState()
+            .AddAspirateServices()
+            .AddAspirateActions()
+            .AddAspirateProcessors()
+            .AddAspirateSecretProvider()
+            .AddPlaceholderTransformation()
+            .AddSingleton(AnsiConsole.Console);
+
+        return ExecuteCommand(services);
+    }
 
     protected virtual Task<int> ExecuteCommand(IServiceCollection services) => Task.FromResult(0);
 


### PR DESCRIPTION
## Summary
- ensure GenericCommand initializes its service collection

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj` *(fails: 'ParseResult' does not contain a definition for 'GetValueForOption')*

------
https://chatgpt.com/codex/tasks/task_e_6870d26140908331a36aaaa90f152426