### PR TITLE
Add overlay docs and usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,14 @@ Builds can be skipped by passing the `--skip-build` flag.
 
 Your manifests will be in the AppHost/aspirate-output directory by default.
 
+### Using Overlays
+
 If you maintain environment specific overlays, pass `--overlay-path` (or set
 `ASPIRATE_OVERLAY_PATH`) to build that overlay instead of the base manifests.
+When an overlay lacks `.secrets` files for a component, Aspirate automatically
+creates empty files so kustomize can process the directory.
+
+See the [Using Overlays](https://prom3theu5.github.io/aspirational-manifests/using-overlays.html) documentation for details.
 
 ```bash
 aspirate generate --overlay-path overlays/dev

--- a/docs/Writerside/hi.tree
+++ b/docs/Writerside/hi.tree
@@ -33,6 +33,7 @@
     <toc-element topic="File-Permissions.md"/>
     <toc-element topic="External-Providers.md"/>
     <toc-element topic="Ingress-Support.md"/>
+    <toc-element topic="Using-Overlays.md"/>
     <toc-element topic="Dapr-Support.md"/>
     <toc-element topic="Security-Best-Practices.md"/>
     <toc-element topic="Troubleshooting.md"/>

--- a/docs/Writerside/topics/Generate-Command.md
+++ b/docs/Writerside/topics/Generate-Command.md
@@ -12,6 +12,19 @@ Builds can be skipped by passing the `--skip-build` flag.
 
 Your manifests will be in the `%output-dir%` directory by default.
 
+### Using Overlays
+
+To build a specific overlay, supply `--overlay-path` (or `ASPIRATE_OVERLAY_PATH`).
+If a component directory in the overlay lacks a `.secrets` file, Aspir8 creates
+an empty one so kustomize can run.
+
+```bash
+aspirate generate --overlay-path overlays/dev
+```
+
+See [Using Overlays](Using-Overlays.md) for details on directory structure and
+patch examples.
+
 ## Compose
 
 The output format of the manifest can also be changed to compose to generate a lightweight deployment (docker/podman compose).

--- a/docs/Writerside/topics/Using-Overlays.md
+++ b/docs/Writerside/topics/Using-Overlays.md
@@ -1,0 +1,46 @@
+# Using Overlays
+
+Kustomize overlays allow you to keep environment specific patches outside of the base manifests.
+An overlay directory typically mirrors the structure created by `aspirate generate` with a `kustomization.yaml` file and subdirectories for each component.
+
+```
+overlays/
+  dev/
+    kustomization.yaml
+    webapi/
+      deployment-patch.yaml
+      .webapi.secrets
+    postgrescontainer/
+      statefulset-patch.yaml
+      .postgrescontainer.secrets
+```
+
+`.secrets` files store values referenced by `secretGenerator` entries. If a component directory does not contain one, Aspir8 creates an empty file so kustomize continues without error.
+
+Common patches include adjusting replica counts, setting resource limits or overriding environment variables. Example to scale a deployment:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webapi
+spec:
+  replicas: 2
+```
+
+Example to set an environment variable:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webapi
+spec:
+  template:
+    spec:
+      containers:
+        - name: webapi
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Development
+```


### PR DESCRIPTION
## Summary
- document `--overlay-path` usage in README
- add a Using Overlays docs page and link from table of contents
- show overlay example in the Generate command docs

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e709e9048331a99dac2a0f285df4