### PR TITLE
Add overlay path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ To apply the manifests to your cluster, run:
 ```bash
 aspirate apply
 ```
+If an overlay path was provided with the `generate` command, aspirate will use that overlay when applying.
 
 Aspirate will first ask you which context they would like you to operate on, and will confirm first that you wish to act.
 
@@ -123,6 +124,7 @@ To remove the manifests from your cluster, run:
 ```bash
 aspirate destroy
 ```
+If an overlay path was provided with the `generate` command, aspirate will use that overlay when removing manifests.
 
 Aspirate will first ask you which context they would like you to operate on, and will confirm first that you wish to act.
 

--- a/docs/Writerside/topics/Apply-Manifests.md
+++ b/docs/Writerside/topics/Apply-Manifests.md
@@ -2,6 +2,8 @@
 
 To apply the manifests to your cluster, run:
 
+If an overlay path was provided during `generate`, Aspirate uses that directory when applying manifests.
+
 ```bash
 aspirate apply
 ```

--- a/docs/Writerside/topics/Generate-Command.md
+++ b/docs/Writerside/topics/Generate-Command.md
@@ -76,6 +76,10 @@ When ran non-interactively, you can specify which components to build with `-c` 
 | --project-path                | -p    | `ASPIRATE_PROJECT_PATH`                    | The path to the aspire project.                                                                                                                                                              |
 | --aspire-manifest             | -m    | `ASPIRATE_ASPIRE_MANIFEST_PATH`            | The aspire manifest file to use                                                                                                                                                              |
 | --output-path                 | -o    | `ASPIRATE_OUTPUT_PATH`                     | The path to the output directory. Defaults to `%output-dir%`                                                                                                                                 |
+| --overlay-path                | -op   | `ASPIRATE_OVERLAY_PATH`
+    | Optional kustomize overlay directory applied during `apply` and `destroy`
+
+                                    |
 | --skip-build                  |       | `ASPIRATE_SKIP_BUILD`                      | Skips build and Push of containers.                                                                                                                                                          |
 | --disable-state               |       | `ASPIRATE_DISABLE_STATE`                   | Disable aspirate state management.                                                                                                                                                           |
 | --namespace                   |       | `ASPIRATE_NAMESPACE`                       | Generates a Kubernetes Namespace resource, and applies the namespace to all generated resources. Will be used at deployment time.                                                            |

--- a/docs/Writerside/topics/Removing-Manifests-from-a-Cluster.md
+++ b/docs/Writerside/topics/Removing-Manifests-from-a-Cluster.md
@@ -2,6 +2,8 @@
 
 To remove the manifests from your cluster, run:
 
+If an overlay path was provided during `generate`, Aspirate uses that directory when removing manifests.
+
 ```bash
 aspirate destroy
 ```

--- a/src/Aspirate.Commands/Commands/Generate/GenerateCommand.cs
+++ b/src/Aspirate.Commands/Commands/Generate/GenerateCommand.cs
@@ -33,5 +33,6 @@ public sealed class GenerateCommand : BaseCommand<GenerateOptions, GenerateComma
         Options.Add(ReplaceSecretsOption.Instance);
         Options.Add(ParameterResourceValueOption.Instance);
         Options.Add(ComponentsOption.Instance);
+        Options.Add(OverlayPathOption.Instance);
     }
 }

--- a/src/Aspirate.Commands/Commands/Generate/GenerateOptions.cs
+++ b/src/Aspirate.Commands/Commands/Generate/GenerateOptions.cs
@@ -36,4 +36,5 @@ public sealed class GenerateOptions : BaseCommandOptions,
     public bool? IncludeDashboard { get; set; }
     public bool? ReplaceSecrets { get; set; }
     public List<string>? CliSpecifiedComponents { get; set; }
+    public string? OverlayPath { get; set; }
 }

--- a/src/Aspirate.Commands/Options/OverlayPathOption.cs
+++ b/src/Aspirate.Commands/Options/OverlayPathOption.cs
@@ -1,0 +1,21 @@
+namespace Aspirate.Commands.Options;
+
+public sealed class OverlayPathOption : BaseOption<string?>
+{
+    private static readonly string[] _aliases =
+    [
+        "-op",
+        "--overlay-path"
+    ];
+
+    private OverlayPathOption() : base(nameof(IGenerateOptions.OverlayPath), _aliases, "ASPIRATE_OVERLAY_PATH", null)
+    {
+        Description = "The path to a kustomize overlay directory";
+        Arity = ArgumentArity.ExactlyOne;
+        Required = false;
+    }
+
+    public static OverlayPathOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
+}

--- a/src/Aspirate.Services/Implementations/KustomizeService.cs
+++ b/src/Aspirate.Services/Implementations/KustomizeService.cs
@@ -55,9 +55,11 @@ public class KustomizeService(IFileSystem fileSystem, IShellExecutionService she
             return;
         }
 
-        var basePath = !string.IsNullOrEmpty(state.InputPath)
-            ? state.InputPath
-            : fileSystem.Path.GetTempPath();
+        var basePath = !string.IsNullOrEmpty(state.OverlayPath)
+            ? state.OverlayPath!
+            : !string.IsNullOrEmpty(state.InputPath)
+                ? state.InputPath!
+                : fileSystem.Path.GetTempPath();
 
         foreach (var resourceSecrets in secretProvider.State.Secrets.Where(x => x.Value.Keys.Count > 0))
         {

--- a/src/Aspirate.Shared/Interfaces/Commands/Contracts/IGenerateOptions.cs
+++ b/src/Aspirate.Shared/Interfaces/Commands/Contracts/IGenerateOptions.cs
@@ -9,4 +9,5 @@ public interface IGenerateOptions
     string? ImagePullPolicy { get; set; }
     string? OutputFormat { get; set; }
     List<string>? Parameters { get; set; }
+    string? OverlayPath { get; set; }
 }

--- a/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
@@ -28,6 +28,10 @@ public class AspirateState :
     public string? OutputPath { get; set; }
 
     [RestorableStateProperty]
+    [JsonPropertyName("overlayPath")]
+    public string? OverlayPath { get; set; }
+
+    [RestorableStateProperty]
     [JsonPropertyName("launchProfile")]
     public string? LaunchProfile { get; set; }
 

--- a/tests/Aspirate.Tests/ActionsTests/Manifests/RemoveManifestsToClusterActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Manifests/RemoveManifestsToClusterActionTests.cs
@@ -108,4 +108,37 @@ public class RemoveManifestsToClusterActionTests : BaseActionTests<RemoveManifes
         // Assert
         result.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task RemoveManifests_UsesOverlayPath_WhenSet()
+    {
+        var state = CreateAspirateState(nonInteractive: true, projectPath: DefaultProjectPath, inputPath: "/some-path", kubeContext: "docker-desktop");
+        state.OverlayPath = "/overlay";
+
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddDirectory("/overlay");
+
+        var kubeCtl = Substitute.For<IKubeCtlService>();
+        kubeCtl.RemoveManifests(Arg.Any<string>(), Arg.Any<string>()).Returns(Task.FromResult(true));
+
+        var services = new ServiceCollection();
+        services.RegisterAspirateEssential();
+        services.RemoveAll<IFileSystem>();
+        services.RemoveAll<IAnsiConsole>();
+        services.RemoveAll<AspirateState>();
+        services.RemoveAll<IKubeCtlService>();
+
+        services.AddSingleton<IFileSystem>(fileSystem);
+        services.AddSingleton<IAnsiConsole>(new TestConsole());
+        services.AddSingleton(state);
+        services.AddSingleton(Substitute.For<IShellExecutionService>());
+        services.AddSingleton(kubeCtl);
+
+        var provider = services.BuildServiceProvider();
+        var action = GetSystemUnderTest(provider);
+
+        await action.ExecuteAsync();
+
+        await kubeCtl.Received().RemoveManifests(state.KubeContext, "/overlay");
+    }
 }

--- a/tests/Aspirate.Tests/ExtensionTests/AspirateStateExtensionsTests.cs
+++ b/tests/Aspirate.Tests/ExtensionTests/AspirateStateExtensionsTests.cs
@@ -30,6 +30,7 @@ public class AspirateStateExtensionsTests
         public string? ContainerRepositoryPrefix { get; set; }
         public List<string>? ContainerImageTags { get; set; }
         public List<string>? ContainerBuildArgs { get; set; }
+        public string? OverlayPath { get; set; }
     }
 
     [Fact]
@@ -44,6 +45,17 @@ public class AspirateStateExtensionsTests
 
         // Assert
         state.ContainerBuilder.Should().Be(ContainerBuilder.Docker.Value);
+    }
+
+    [Fact]
+    public void PopulateStateFromOptions_OverlayPathStored()
+    {
+        var state = new AspirateState();
+        var options = new TestOptions { OverlayPath = "/over" };
+
+        state.PopulateStateFromOptions(options);
+
+        state.OverlayPath.Should().Be("/over");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add OverlayPath to AspirateState and GenerateOptions
- add OverlayPath CLI option to Generate command
- honor overlay path when applying or removing manifests
- document overlay path usage
- test state persistence and manifest actions

## Testing
- `dotnet --version`
- `dotnet test` *(fails: NETSDK1045 - .NET 9 SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68749c215d3c8331a635c6baefd02e57