### PR TITLE
Fix secrets path when overlay used

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/RemoveManifestsFromClusterAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/RemoveManifestsFromClusterAction.cs
@@ -84,7 +84,7 @@ public sealed class RemoveManifestsFromClusterAction(
             return;
         }
 
-        var manifestsPath = GetManifestsPath();
+        var manifestsPath = CurrentState.InputPath!;
 
         foreach (var resourceSecrets in secretProvider.State.Secrets.Where(x => x.Value.Keys.Count > 0))
         {

--- a/src/Aspirate.Services/Implementations/KustomizeService.cs
+++ b/src/Aspirate.Services/Implementations/KustomizeService.cs
@@ -55,11 +55,9 @@ public class KustomizeService(IFileSystem fileSystem, IShellExecutionService she
             return;
         }
 
-        var basePath = !string.IsNullOrEmpty(state.OverlayPath)
-            ? state.OverlayPath!
-            : !string.IsNullOrEmpty(state.InputPath)
-                ? state.InputPath!
-                : fileSystem.Path.GetTempPath();
+        var basePath = !string.IsNullOrEmpty(state.InputPath)
+            ? state.InputPath!
+            : fileSystem.Path.GetTempPath();
 
         foreach (var resourceSecrets in secretProvider.State.Secrets.Where(x => x.Value.Keys.Count > 0))
         {


### PR DESCRIPTION
## Summary
- ensure secret files are written using the input path
- keep overlay path only for kubectl operations
- cover secret path behaviour when overlay path is set

## Testing
- `dotnet test Aspirate.sln --verbosity minimal` *(fails: dotnet 9 not available)*

------
https://chatgpt.com/codex/tasks/task_e_6874a2313c0c8331b75124cc777ca7c4