### PR TITLE
Ensure base manifests applied before overlay

### DIFF
--- a/docs/Writerside/topics/Apply-Manifests.md
+++ b/docs/Writerside/topics/Apply-Manifests.md
@@ -2,7 +2,7 @@
 
 To apply the manifests to your cluster, run:
 
-If an overlay path was provided during `generate`, Aspirate uses that directory when applying manifests.
+If an overlay path was provided during `generate`, Aspirate first applies the manifests from the input directory and then applies the files in the overlay directory.
 
 ```bash
 aspirate apply

--- a/docs/Writerside/topics/Removing-Manifests-from-a-Cluster.md
+++ b/docs/Writerside/topics/Removing-Manifests-from-a-Cluster.md
@@ -2,7 +2,7 @@
 
 To remove the manifests from your cluster, run:
 
-If an overlay path was provided during `generate`, Aspirate uses that directory when removing manifests.
+If an overlay path was provided during `generate`, Aspirate removes the manifests from the input directory first and then deletes those in the overlay directory.
 
 ```bash
 aspirate destroy

--- a/src/Aspirate.Commands/Actions/Manifests/ApplyManifestsToClusterAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ApplyManifestsToClusterAction.cs
@@ -15,6 +15,8 @@ public sealed class ApplyManifestsToClusterAction(
 
         var secretFiles = new List<string>();
         var manifestsPath = GetManifestsPath();
+        var overlayPath = CurrentState.OverlayPath;
+        var basePath = CurrentState.InputPath!;
 
         try
         {
@@ -32,7 +34,12 @@ public sealed class ApplyManifestsToClusterAction(
                 await kubeCtlService.ApplyManifestFile(CurrentState.KubeContext, imagePullSecretFile);
             }
 
-            await kubeCtlService.ApplyManifests(CurrentState.KubeContext, manifestsPath);
+            await kubeCtlService.ApplyManifests(CurrentState.KubeContext, basePath);
+
+            if (!string.IsNullOrEmpty(overlayPath))
+            {
+                await kubeCtlService.ApplyManifests(CurrentState.KubeContext, overlayPath);
+            }
             await HandleRollingRestart();
             Logger.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done:[/] Deployments successfully applied to cluster [blue]'{CurrentState.KubeContext}'[/]");
 

--- a/src/Aspirate.Commands/Actions/Manifests/RemoveManifestsFromClusterAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/RemoveManifestsFromClusterAction.cs
@@ -14,13 +14,20 @@ public sealed class RemoveManifestsFromClusterAction(
 
         var secretFiles = new List<string>();
         var manifestsPath = GetManifestsPath();
+        var overlayPath = CurrentState.OverlayPath;
+        var basePath = CurrentState.InputPath!;
 
         try
         {
             await InteractivelySelectKubernetesCluster();
 
             CreateEmptySecretFiles(secretFiles);
-            await kubeCtlService.RemoveManifests(CurrentState.KubeContext, manifestsPath);
+            await kubeCtlService.RemoveManifests(CurrentState.KubeContext, basePath);
+
+            if (!string.IsNullOrEmpty(overlayPath))
+            {
+                await kubeCtlService.RemoveManifests(CurrentState.KubeContext, overlayPath);
+            }
             Logger.MarkupLine(
                 $"[green]({EmojiLiterals.CheckMark}) Done:[/] Deployments removed from cluster [blue]'{CurrentState.KubeContext}'[/]");
 

--- a/tests/Aspirate.Tests/ActionsTests/Manifests/ApplyManifestsToClusterActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Manifests/ApplyManifestsToClusterActionTests.cs
@@ -187,6 +187,7 @@ public class ApplyManifestsToClusterActionTests : BaseActionTests<ApplyManifests
 
         await action.ExecuteAsync();
 
+        await kubeCtl.Received().ApplyManifests(state.KubeContext, "/some-path");
         await kubeCtl.Received().ApplyManifests(state.KubeContext, "/overlay");
     }
 }

--- a/tests/Aspirate.Tests/ActionsTests/Manifests/RemoveManifestsToClusterActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Manifests/RemoveManifestsToClusterActionTests.cs
@@ -139,6 +139,7 @@ public class RemoveManifestsToClusterActionTests : BaseActionTests<RemoveManifes
 
         await action.ExecuteAsync();
 
+        await kubeCtl.Received().RemoveManifests(state.KubeContext, "/some-path");
         await kubeCtl.Received().RemoveManifests(state.KubeContext, "/overlay");
     }
 }


### PR DESCRIPTION
## Summary
- update apply action to always apply base manifests before overlay
- update removal action to remove both base and overlay manifests
- test for multiple calls when an overlay directory is provided
- document new overlay behaviour

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build --verbosity minimal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6874db529a9083318d0dbf384138eaa6