### PR TITLE
Prevent kubectl delete errors

### DIFF
--- a/src/Aspirate.Services/Implementations/KubeCtlService.cs
+++ b/src/Aspirate.Services/Implementations/KubeCtlService.cs
@@ -93,7 +93,8 @@ public partial class KubeCtlService(IFileSystem filesystem, IAnsiConsole console
         var argumentsBuilder = ArgumentsBuilder.Create()
             .AppendArgument(KubeCtlLiterals.KubeCtlDeleteArgument, string.Empty, quoteValue: false)
             .AppendArgument(KubeCtlLiterals.KubeCtlKustomizeManifestsArgument, fullOutputPath, quoteValue: false)
-            .AppendArgument(KubeCtlLiterals.KubeCtlNoWaitArgument, string.Empty, quoteValue: false);
+            .AppendArgument(KubeCtlLiterals.KubeCtlNoWaitArgument, string.Empty, quoteValue: false)
+            .AppendArgument(KubeCtlLiterals.KubeCtlIgnoreNotFoundArgument, string.Empty, quoteValue: false);
 
         var executionOptions = new ShellCommandOptions
         {

--- a/src/Aspirate.Shared/Literals/KubeCtlLiterals.cs
+++ b/src/Aspirate.Shared/Literals/KubeCtlLiterals.cs
@@ -15,6 +15,7 @@ public static class KubeCtlLiterals
     public const string KubeCtlRolloutArgument = "rollout";
     public const string KubeCtlNamespaceArgument = "-n";
     public const string KubeCtlNoWaitArgument = "--wait=false";
+    public const string KubeCtlIgnoreNotFoundArgument = "--ignore-not-found=true";
     public const string KubeCtlServerSideArgument = "--server-side";
     public const string KubeCtlFileArgument = "-f";
 


### PR DESCRIPTION
## Summary
- ensure `kubectl delete` ignores missing resources

## Testing
- `dotnet build` *(fails: current .NET SDK doesn't support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6874e05462ac8331a4103dca797896d0