### PR TITLE
Fix security context prompt

### DIFF
--- a/src/Aspirate.Commands/Commands/Generate/GenerateCommandHandler.cs
+++ b/src/Aspirate.Commands/Commands/Generate/GenerateCommandHandler.cs
@@ -35,6 +35,7 @@ public sealed class GenerateCommandHandler(IServiceProvider serviceProvider) : B
             .QueueAction(nameof(BuildAndPushContainersFromProjectsAction))
             .QueueAction(nameof(BuildAndPushContainersFromDockerfilesAction))
             .QueueAction(nameof(SaveSecretsAction))
+            .QueueAction(nameof(ConfigureSecurityContextAction))
             .QueueAction(nameof(AskImagePullPolicyAction));
 
     private Task<int> GenerateDockerComposeManifests() =>

--- a/src/Aspirate.Commands/Commands/Run/RunCommandHandler.cs
+++ b/src/Aspirate.Commands/Commands/Run/RunCommandHandler.cs
@@ -17,6 +17,7 @@ public sealed class RunCommandHandler(IServiceProvider serviceProvider) : BaseCo
             .QueueAction(nameof(BuildAndPushContainersFromDockerfilesAction))
             .QueueAction(nameof(AskImagePullPolicyAction))
             .QueueAction(nameof(SaveSecretsAction))
+            .QueueAction(nameof(ConfigureSecurityContextAction))
             .QueueAction(nameof(CustomNamespaceAction))
             .QueueAction(nameof(RunKubernetesObjectsAction))
             .ExecuteCommandsAsync();


### PR DESCRIPTION
## Summary
- wire ConfigureSecurityContextAction into `generate` and `run` command handlers

## Testing
- `dotnet test` *(fails: `CS1061` compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875fc46ae088331889f3545aad5390a