### PR TITLE
Support fsGroup in manifests

### DIFF
--- a/src/Aspirate.Cli/Templates/deployment.hbs
+++ b/src/Aspirate.Cli/Templates/deployment.hbs
@@ -29,18 +29,45 @@ spec:
         {{@key}}: {{this}}
       {{/each}}
 {{/if}}
-    spec:
-    {{#if withPrivateRegistry}}
-      imagePullSecrets:
-      - name: image-pull-secret
-    {{/if}}
-      containers:
-      - name: {{name}}
-        image: {{containerImage}}
-        imagePullPolicy: {{imagePullPolicy}}
-        {{#if entrypoint}}
-        command:
-          - {{entrypoint}}
+      spec:
+      {{#if withPrivateRegistry}}
+        imagePullSecrets:
+        - name: image-pull-secret
+      {{/if}}
+      {{#if PodSecurityContext}}
+        securityContext:
+        {{#if PodSecurityContext.RunAsUser}}
+          runAsUser: {{PodSecurityContext.RunAsUser}}
+        {{/if}}
+        {{#if PodSecurityContext.RunAsGroup}}
+          runAsGroup: {{PodSecurityContext.RunAsGroup}}
+        {{/if}}
+        {{#if PodSecurityContext.FsGroup}}
+          fsGroup: {{PodSecurityContext.FsGroup}}
+        {{/if}}
+        {{#if PodSecurityContext.RunAsNonRoot}}
+          runAsNonRoot: true
+        {{/if}}
+      {{/if}}
+        containers:
+          - name: {{name}}
+            image: {{containerImage}}
+            imagePullPolicy: {{imagePullPolicy}}
+          {{#if ContainerSecurityContext}}
+          securityContext:
+            {{#if ContainerSecurityContext.RunAsUser}}
+            runAsUser: {{ContainerSecurityContext.RunAsUser}}
+            {{/if}}
+            {{#if ContainerSecurityContext.RunAsGroup}}
+            runAsGroup: {{ContainerSecurityContext.RunAsGroup}}
+            {{/if}}
+            {{#if ContainerSecurityContext.RunAsNonRoot}}
+            runAsNonRoot: true
+            {{/if}}
+          {{/if}}
+          {{#if entrypoint}}
+          command:
+            - {{entrypoint}}
         {{/if}}
         {{#if hasArgs}}
         args:
@@ -81,3 +108,4 @@ spec:
         {{/each}}
         {{/if}}
       terminationGracePeriodSeconds: 180
+

--- a/src/Aspirate.Cli/Templates/statefulset.hbs
+++ b/src/Aspirate.Cli/Templates/statefulset.hbs
@@ -32,10 +32,37 @@ spec:
       imagePullSecrets:
         - name: image-pull-secret
         {{/if}}
+    {{#if PodSecurityContext}}
+      securityContext:
+        {{#if PodSecurityContext.RunAsUser}}
+        runAsUser: {{PodSecurityContext.RunAsUser}}
+        {{/if}}
+        {{#if PodSecurityContext.RunAsGroup}}
+        runAsGroup: {{PodSecurityContext.RunAsGroup}}
+        {{/if}}
+        {{#if PodSecurityContext.FsGroup}}
+        fsGroup: {{PodSecurityContext.FsGroup}}
+        {{/if}}
+        {{#if PodSecurityContext.RunAsNonRoot}}
+        runAsNonRoot: true
+        {{/if}}
+    {{/if}}
       containers:
         - name: {{name}}
           image: {{containerImage}}
           imagePullPolicy: {{imagePullPolicy}}
+          {{#if ContainerSecurityContext}}
+          securityContext:
+            {{#if ContainerSecurityContext.RunAsUser}}
+            runAsUser: {{ContainerSecurityContext.RunAsUser}}
+            {{/if}}
+            {{#if ContainerSecurityContext.RunAsGroup}}
+            runAsGroup: {{ContainerSecurityContext.RunAsGroup}}
+            {{/if}}
+            {{#if ContainerSecurityContext.RunAsNonRoot}}
+            runAsNonRoot: true
+            {{/if}}
+          {{/if}}
           {{#if entrypoint}}
           command:
             - {{entrypoint}}


### PR DESCRIPTION
## Summary
- include Pod and container security contexts in deployment and statefulset templates

## Testing
- `dotnet test Aspirate.sln --list-tests` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6875ffdc8e648331b5fc9d7dc6d86184