### PR TITLE
Fix deployment template indentation

### DIFF
--- a/src/Aspirate.Cli/Templates/deployment.hbs
+++ b/src/Aspirate.Cli/Templates/deployment.hbs
@@ -29,30 +29,30 @@ spec:
         {{@key}}: {{this}}
       {{/each}}
 {{/if}}
-      spec:
-      {{#if withPrivateRegistry}}
-        imagePullSecrets:
-        - name: image-pull-secret
+    spec:
+    {{#if withPrivateRegistry}}
+      imagePullSecrets:
+      - name: image-pull-secret
+    {{/if}}
+    {{#if PodSecurityContext}}
+      securityContext:
+      {{#if PodSecurityContext.RunAsUser}}
+        runAsUser: {{PodSecurityContext.RunAsUser}}
       {{/if}}
-      {{#if PodSecurityContext}}
-        securityContext:
-        {{#if PodSecurityContext.RunAsUser}}
-          runAsUser: {{PodSecurityContext.RunAsUser}}
-        {{/if}}
-        {{#if PodSecurityContext.RunAsGroup}}
-          runAsGroup: {{PodSecurityContext.RunAsGroup}}
-        {{/if}}
-        {{#if PodSecurityContext.FsGroup}}
-          fsGroup: {{PodSecurityContext.FsGroup}}
-        {{/if}}
-        {{#if PodSecurityContext.RunAsNonRoot}}
-          runAsNonRoot: true
-        {{/if}}
+      {{#if PodSecurityContext.RunAsGroup}}
+        runAsGroup: {{PodSecurityContext.RunAsGroup}}
       {{/if}}
-        containers:
-          - name: {{name}}
-            image: {{containerImage}}
-            imagePullPolicy: {{imagePullPolicy}}
+      {{#if PodSecurityContext.FsGroup}}
+        fsGroup: {{PodSecurityContext.FsGroup}}
+      {{/if}}
+      {{#if PodSecurityContext.RunAsNonRoot}}
+        runAsNonRoot: true
+      {{/if}}
+    {{/if}}
+      containers:
+        - name: {{name}}
+          image: {{containerImage}}
+          imagePullPolicy: {{imagePullPolicy}}
           {{#if ContainerSecurityContext}}
           securityContext:
             {{#if ContainerSecurityContext.RunAsUser}}


### PR DESCRIPTION
## Summary
- fix indentation in deployment template so `.spec.template.spec` fields render correctly

## Testing
- `dotnet test tests/Aspirate.Tests/Aspirate.Tests.csproj --no-build --verbosity normal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68760335a9a8833198aa6973619488e2